### PR TITLE
Revamp UI with shadcn-aligned design system

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -41,8 +41,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "12kb",
-                  "maximumError": "16kb"
+                  "maximumWarning": "30kb",
+                  "maximumError": "40kb"
                 }
               ],
               "optimization": true,

--- a/src/app/prediction-tool/prediction-tool.component.css
+++ b/src/app/prediction-tool/prediction-tool.component.css
@@ -2,391 +2,606 @@
   display: block;
 }
 
+/* ── Shell ──────────────────────────────────────────────────────── */
 .shell {
   position: relative;
   isolation: isolate;
-  overflow: hidden;
   min-height: 100vh;
-  padding: 26px 28px 42px;
-  transition:
-    background 0.45s ease,
-    color 0.3s ease;
 }
 
-.shell::before,
-.shell::after {
-  content: '';
-  position: fixed;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.shell::before {
-  inset: 0;
-  background-image:
-    linear-gradient(var(--mesh-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--mesh-line) 1px, transparent 1px);
-  background-size: 42px 42px;
-  mask-image: radial-gradient(circle at center, black 40%, transparent 88%);
-  -webkit-mask-image: radial-gradient(circle at center, black 40%, transparent 88%);
-  opacity: 0.22;
-}
-
-.shell::after {
-  width: 46vw;
-  height: 46vw;
-  max-width: 560px;
-  max-height: 560px;
-  top: -180px;
-  right: -140px;
-  border-radius: 50%;
-  background: radial-gradient(circle, var(--orb-color) 0%, transparent 68%);
-  filter: blur(12px);
-  opacity: 0.78;
-  transition: background 0.45s ease;
-}
-
-.theme-light {
-  --text-color: #1f2328;
-  --text-muted: #74685b;
-  --primary-color: #234b61;
-  --accent-color: #af6542;
-  --btn-text: #fffaf3;
-  --line-soft: rgba(116, 92, 68, 0.14);
-  --panel-bg: rgba(255, 250, 244, 0.72);
-  --panel-strong: rgba(255, 253, 250, 0.82);
-  --results-bg: rgba(255, 252, 248, 0.9);
-  --results-bg-2: rgba(249, 243, 236, 0.84);
-  --price-panel-bg: rgba(255, 255, 255, 0.46);
-  --field-bg: rgba(255, 255, 255, 0.54);
-  --pill-bg: rgba(255, 251, 246, 0.56);
-  --focus-ring: rgba(35, 75, 97, 0.12);
-  --panel-shadow: rgba(110, 84, 63, 0.12);
-  --accent-shadow: rgba(175, 101, 66, 0.24);
-  --mesh-line: rgba(31, 35, 40, 0.04);
-  --orb-color: rgba(175, 101, 66, 0.14);
-  --error-bg: rgba(175, 101, 66, 0.1);
-  --error-border: rgba(175, 101, 66, 0.24);
-  background: linear-gradient(155deg, #f5eee5 0%, #eee4d8 50%, #ece6de 100%);
-  color: var(--text-color);
-}
-
-.theme-dark {
-  --text-color: #f2ede6;
-  --text-muted: #9e998f;
-  --primary-color: #8daec1;
-  --accent-color: #cf8b60;
-  --btn-text: #fffaf3;
-  --line-soft: rgba(141, 174, 193, 0.16);
-  --panel-bg: rgba(16, 23, 31, 0.78);
-  --panel-strong: rgba(18, 27, 37, 0.88);
-  --results-bg: rgba(18, 26, 35, 0.92);
-  --results-bg-2: rgba(15, 22, 30, 0.86);
-  --price-panel-bg: rgba(255, 255, 255, 0.04);
-  --field-bg: rgba(255, 255, 255, 0.04);
-  --pill-bg: rgba(255, 255, 255, 0.04);
-  --focus-ring: rgba(141, 174, 193, 0.14);
-  --panel-shadow: rgba(0, 0, 0, 0.32);
-  --accent-shadow: rgba(207, 139, 96, 0.26);
-  --mesh-line: rgba(255, 255, 255, 0.06);
-  --orb-color: rgba(207, 139, 96, 0.18);
-  --error-bg: rgba(207, 139, 96, 0.14);
-  --error-border: rgba(207, 139, 96, 0.28);
-  background: linear-gradient(155deg, #091017 0%, #101821 52%, #1a2430 100%);
-  color: var(--text-color);
-}
-
-.surface {
-  position: relative;
-  z-index: 1;
+.page-surface {
   max-width: 1280px;
   margin: 0 auto;
+  padding: 0 24px;
 }
 
-/* --- Topbar --- */
-.topbar {
+/* ── Sticky Header ──────────────────────────────────────────────── */
+.sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  margin: 0 -24px 24px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
-  margin-bottom: 28px;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 8px 14px;
-  border: 1px solid var(--line-soft);
-  border-radius: 999px;
-  background: var(--pill-bg);
-  color: var(--accent-color);
-  font-size: 11px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 1.4px;
+  gap: 14px;
+  padding: 14px 24px;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+  background: color-mix(in oklab, var(--background) 85%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  transition: background 0.3s ease, border-color 0.3s ease;
 }
 
-.actions {
+.brand-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid color-mix(in oklab, var(--primary) 20%, transparent);
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  white-space: nowrap;
+  transition: background 200ms ease, border-color 200ms ease, color 200ms ease;
+}
+
+.brand-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--primary);
+  transition: background 200ms ease;
+}
+
+.header-actions {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
 }
 
-/* --- Buttons --- */
-.ghost-btn {
-  min-height: 42px;
-  padding: 10px 16px;
-  border-radius: 999px;
-  background: var(--panel-strong);
-  color: var(--text-color);
-  border: 1px solid var(--line-soft);
+/* ── Buttons ────────────────────────────────────────────────────── */
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 36px;
+  padding: 8px 14px;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.4);
+  background: var(--card);
+  color: var(--foreground);
   font: inherit;
-  font-weight: 700;
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
   cursor: pointer;
-  transition: transform 160ms ease, background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  transition:
+    transform 160ms ease,
+    background 200ms ease,
+    color 200ms ease,
+    border-color 200ms ease;
 }
-.ghost-btn:hover { transform: translateY(-1px); }
-.ghost-btn:active { transform: translateY(0); }
-.ghost-btn:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus-ring); }
+.btn-outline:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: var(--secondary);
+}
+.btn-outline:active:not(:disabled) {
+  transform: translateY(0);
+}
+.btn-outline:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 25%, transparent);
+}
+.btn-outline:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
-.btn-primary {
-  min-height: 54px;
-  padding: 14px 28px;
-  border-radius: 999px;
-  background: var(--accent-color);
-  color: var(--btn-text);
-  border: none;
-  box-shadow: 0 16px 30px var(--accent-shadow);
-  font: inherit;
-  font-weight: 700;
-  font-size: 1rem;
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.4);
+  background: var(--card);
+  color: var(--foreground);
   cursor: pointer;
-  transition: transform 160ms ease, opacity 160ms ease, background 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    transform 160ms ease,
+    background 200ms ease,
+    color 200ms ease,
+    border-color 200ms ease;
 }
-.btn-primary:hover:not(:disabled) { transform: translateY(-1px); }
-.btn-primary:active:not(:disabled) { transform: translateY(0); }
-.btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus-ring); }
-.btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
-.btn-primary:disabled:has(.loading-pulse) { cursor: progress; }
-
-.btn-reset {
-  min-height: 54px;
-  padding: 14px 28px;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--text-color);
-  border: 1px solid var(--line-soft);
-  font: inherit;
-  font-weight: 700;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: transform 160ms ease, background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+.btn-icon svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
 }
-.btn-reset:hover:not(:disabled) { transform: translateY(-1px); }
-.btn-reset:active:not(:disabled) { transform: translateY(0); }
-.btn-reset:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus-ring); }
+.btn-icon:hover {
+  transform: translateY(-1px);
+  background: var(--secondary);
+}
+.btn-icon:active {
+  transform: translateY(0);
+}
+.btn-icon:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 25%, transparent);
+}
 
-/* --- Layout --- */
-.layout {
+/* ── Skeleton ───────────────────────────────────────────────────── */
+.skeleton {
+  border-radius: calc(var(--radius) * 1.4);
+  background: var(--muted);
+}
+
+.skeleton-animate {
+  background: linear-gradient(
+    110deg,
+    var(--secondary) 8%,
+    color-mix(in oklab, var(--secondary) 60%, var(--primary)) 18%,
+    var(--secondary) 33%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.8s ease-in-out infinite;
+}
+
+/* ── Layout Grid ────────────────────────────────────────────────── */
+.content-grid {
   display: grid;
-  grid-template-columns: minmax(0, 0.94fr) minmax(0, 1.06fr);
-  gap: 22px;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  gap: 20px;
   align-items: start;
+  padding-bottom: 32px;
 }
 
-/* --- Cards --- */
-.card,
-.results-card {
-  border-radius: 30px;
-  border: 1px solid var(--line-soft);
-  box-shadow: 0 24px 70px var(--panel-shadow);
-  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+/* ── Panel Card (shared base) ───────────────────────────────────── */
+.panel-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.8);
+  background: var(--card);
+  box-shadow:
+    0 1px 3px color-mix(in oklab, var(--foreground) 4%, transparent),
+    0 4px 16px color-mix(in oklab, var(--foreground) 6%, transparent);
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    box-shadow 300ms ease;
+}
+.panel-card:hover {
+  box-shadow:
+    0 1px 3px color-mix(in oklab, var(--foreground) 4%, transparent),
+    0 4px 16px color-mix(in oklab, var(--foreground) 6%, transparent),
+    0 8px 32px color-mix(in oklab, var(--primary) 5%, transparent);
 }
 
-.card {
-  background: var(--panel-bg);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+.panel-card-accent {
+  border-left: 4px solid color-mix(in oklab, var(--primary) 70%, transparent);
 }
 
 .card-inner {
-  display: grid;
-  gap: 22px;
   padding: 22px;
+  display: grid;
+  gap: 18px;
 }
 
+/* ── Intro Block ────────────────────────────────────────────────── */
 .intro-block {
   display: grid;
-  gap: 20px;
+  gap: 16px;
 }
 
-/* --- Typography --- */
 .headline {
   margin: 0;
-  max-width: 10ch;
-  color: var(--text-color);
-  font-family:
-    var(--font-display),
-    var(--font-body),
-    'PingFang SC',
-    'Noto Sans SC',
-    sans-serif;
-  font-size: clamp(3rem, 6vw, 5.3rem);
-  line-height: 0.9;
+  color: var(--foreground);
+  font-family: var(--font-display), var(--font-body),
+    'PingFang SC', 'Noto Sans SC', sans-serif;
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.05;
   font-weight: 700;
-  letter-spacing: -0.04em;
-  transition: color 0.3s ease;
+  letter-spacing: -0.03em;
+  white-space: pre-line;
+  transition: color 200ms ease;
 }
 
 .headline-cjk {
   font-family: var(--font-body-cjk);
   font-weight: 800;
-  letter-spacing: -0.02em;
-  line-height: 1.02;
-  max-width: none;
-}
-
-.lead,
-.caption {
-  margin: 0;
-  color: var(--text-muted);
-  transition: color 0.3s ease;
+  line-height: 1.15;
 }
 
 .lead {
-  max-width: 38rem;
+  margin: 0;
+  max-width: 42rem;
+  color: var(--muted-foreground);
   font-size: 1rem;
-  line-height: 1.8;
-}
-
-.caption {
-  font-size: 0.82rem;
   line-height: 1.7;
+  transition: color 200ms ease;
 }
 
-/* --- Figures --- */
+/* ── Stat Tiles ─────────────────────────────────────────────────── */
 .figure-row {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
 }
 
-.figure {
-  padding: 16px 16px 18px;
-  border: 1px solid var(--line-soft);
-  border-radius: 20px;
-  background: var(--panel-strong);
-  transition: background 0.3s ease, border-color 0.3s ease;
+.stat-tile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.4);
+  background: color-mix(in oklab, var(--card) 90%, transparent);
+  box-shadow: 0 1px 2px color-mix(in oklab, var(--foreground) 2%, transparent);
+  transition:
+    transform 200ms ease,
+    background 200ms ease,
+    border-color 200ms ease,
+    box-shadow 200ms ease;
+  cursor: default;
+}
+.stat-tile:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklab, var(--primary) 25%, transparent);
 }
 
-.figure-label {
+.stat-tile-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: calc(var(--radius) * 1.4);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  border: 1px solid color-mix(in oklab, var(--primary) 15%, transparent);
+  color: var(--primary);
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
+}
+.stat-tile:hover .stat-tile-icon {
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  border-color: color-mix(in oklab, var(--primary) 25%, transparent);
+}
+.stat-tile-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.stat-tile-text {
+  min-width: 0;
+}
+
+.stat-tile-label {
   display: block;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
   font-size: 10px;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 1.2px;
-  transition: color 0.3s ease;
+  letter-spacing: 0.8px;
+  transition: color 200ms ease;
 }
 
-.figure-value {
+.stat-tile-value {
   display: block;
-  margin-top: 6px;
-  color: var(--primary-color);
-  font-size: 1.85rem;
+  margin-top: 2px;
+  color: var(--primary);
+  font-family: var(--font-display), var(--font-body),
+    'PingFang SC', 'Noto Sans SC', sans-serif;
+  font-size: 1.25rem;
   font-weight: 800;
-  letter-spacing: -0.04em;
-  transition: color 0.3s ease;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+  transition: color 200ms ease;
 }
 
-/* --- Form Shell --- */
+.caption {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  transition: color 200ms ease;
+}
+
+/* ── Form Shell ─────────────────────────────────────────────────── */
 .form-shell {
-  padding: 22px;
-  border-radius: 24px;
-  background: var(--panel-strong);
-  border: 1px solid var(--line-soft);
-  transition: background 0.3s ease, border-color 0.3s ease;
+  padding: 20px;
+  border-radius: calc(var(--radius) * 1.4);
+  background: var(--secondary);
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
 }
 
 .section-title {
   margin: 0 0 16px;
-  color: var(--primary-color);
-  font-size: 1.35rem;
+  color: var(--primary);
+  font-size: 1rem;
   font-weight: 800;
   letter-spacing: -0.02em;
-  transition: color 0.3s ease;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: color 200ms ease;
 }
 
 .form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0 16px;
+  gap: 14px 16px;
 }
 
 .field-full {
   grid-column: 1 / -1;
 }
 
-.app-field {
-  width: 100%;
+/* ── Form Fields ────────────────────────────────────────────────── */
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
+.field-label {
+  display: block;
+  color: var(--foreground);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: color 200ms ease;
+}
+
+.field-select,
+.field-input {
+  width: 100%;
+  min-height: 42px;
+  padding: 10px 14px;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.4);
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.95rem;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    background 200ms ease,
+    color 200ms ease;
+}
+
+.field-select {
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%2364748b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  padding-right: 38px;
+}
+
+.field-input {
+  cursor: text;
+}
+
+.field-select:hover,
+.field-input:hover {
+  border-color: color-mix(in oklab, var(--primary) 30%, transparent);
+}
+
+.field-select:focus-visible,
+.field-input:focus-visible {
+  border-color: color-mix(in oklab, var(--primary) 50%, transparent);
+  box-shadow:
+    0 0 0 3px color-mix(in oklab, var(--ring) 15%, transparent),
+    0 4px 12px color-mix(in oklab, var(--primary) 5%, transparent);
+}
+
+.field-input::placeholder {
+  color: var(--muted-foreground);
+  font-weight: 500;
+}
+
+/* Unit input wrapper */
 .unit-wrap {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .unit-wrap .field-input {
-  border-radius: 16px 0 0 16px;
+  border-radius: calc(var(--radius) * 1.4) 0 0 calc(var(--radius) * 1.4);
 }
 
 .unit-tag {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 0 18px;
-  min-height: 52px;
-  border: 1px solid var(--line-soft);
+  padding: 0 14px;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
   border-left: none;
-  border-radius: 0 16px 16px 0;
-  background: var(--field-bg);
-  color: var(--text-muted);
-  font-size: 0.88rem;
+  border-radius: 0 calc(var(--radius) * 1.4) calc(var(--radius) * 1.4) 0;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 12px;
   font-weight: 700;
-  transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+  white-space: nowrap;
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
 }
 
+.field-error {
+  display: block;
+  color: var(--destructive);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  transition: color 200ms ease;
+}
+
+/* ── Button Row ─────────────────────────────────────────────────── */
 .button-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
+  margin-top: 6px;
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 46px;
+  padding: 12px 24px;
+  border: none;
+  border-radius: calc(var(--radius) * 1.4);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow:
+    0 4px 12px color-mix(in oklab, var(--primary) 20%, transparent);
+  transition:
+    transform 160ms ease,
+    background 200ms ease,
+    box-shadow 200ms ease,
+    filter 200ms ease;
+}
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  filter: brightness(1.1);
+  box-shadow:
+    0 6px 18px color-mix(in oklab, var(--primary) 25%, transparent);
+}
+.btn-primary:active:not(:disabled) {
+  transform: translateY(0);
+}
+.btn-primary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 25%, transparent);
+}
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary:disabled:has(.loading-pulse) {
+  cursor: progress;
+}
+
+.btn-reset {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 12px 24px;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.4);
+  background: transparent;
+  color: var(--foreground);
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    background 200ms ease,
+    color 200ms ease,
+    border-color 200ms ease;
+}
+.btn-reset:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: color-mix(in oklab, var(--muted) 80%, transparent);
+}
+.btn-reset:active:not(:disabled) {
+  transform: translateY(0);
+}
+.btn-reset:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 25%, transparent);
+}
+.btn-reset:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Error Display ──────────────────────────────────────────────── */
+.error-display {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: calc(var(--radius) * 1.4);
+  border: 1px solid color-mix(in oklab, var(--destructive) 30%, transparent);
+  background: color-mix(in oklab, var(--destructive) 5%, transparent);
+  color: var(--destructive);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
+}
+
+/* ── Progress Track ─────────────────────────────────────────────── */
+.progress-track {
+  position: relative;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--secondary);
+  height: 4px;
   margin-top: 4px;
 }
 
-/* --- Error Banner --- */
-.error-banner {
-  margin: 16px 0 0;
-  padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid var(--error-border);
-  background: var(--error-bg);
-  color: var(--text-color);
-  font-size: 0.92rem;
-  line-height: 1.5;
+.progress-bar {
+  height: 100%;
+  border-radius: 999px;
+  width: 60%;
+  background: linear-gradient(
+    90deg,
+    var(--primary),
+    color-mix(in oklab, var(--primary) 70%, var(--chart-2))
+  );
+  animation: progress-indeterminate 1.8s ease-in-out infinite;
 }
 
-/* --- Results Card --- */
+/* ── Results Panel ──────────────────────────────────────────────── */
 .results-card {
   padding: 22px;
-  background: linear-gradient(
-    180deg,
-    var(--results-bg) 0%,
-    var(--results-bg-2) 100%
-  );
+  border-radius: calc(var(--radius) * 1.8);
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--card) 92%, transparent) 0%,
+      color-mix(in oklab, var(--secondary) 84%, transparent) 100%
+    );
+  box-shadow:
+    0 1px 3px color-mix(in oklab, var(--foreground) 4%, transparent),
+    0 4px 16px color-mix(in oklab, var(--foreground) 6%, transparent);
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    box-shadow 300ms ease;
+  display: grid;
+  gap: 18px;
 }
 
 .results-header {
@@ -394,54 +609,102 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 18px;
-  margin-bottom: 18px;
 }
 
-.results-label {
-  display: block;
-  color: var(--text-muted);
+.results-heading-group {
+  min-width: 0;
+}
+
+.results-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in oklab, var(--primary) 20%, transparent);
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-foreground);
   font-size: 10px;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 1.4px;
-  transition: color 0.3s ease;
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
 }
 
 .results-title {
-  margin: 6px 0 0;
-  color: var(--text-color);
-  font-family:
-    var(--font-display),
-    var(--font-body),
-    'PingFang SC',
-    'Noto Sans SC',
-    sans-serif;
-  font-size: clamp(2.2rem, 4vw, 3.4rem);
-  line-height: 0.95;
+  margin: 0;
+  color: var(--foreground);
+  font-family: var(--font-display), var(--font-body),
+    'PingFang SC', 'Noto Sans SC', sans-serif;
+  font-size: clamp(1.8rem, 3.5vw, 2.4rem);
+  line-height: 1.05;
   font-weight: 700;
-  letter-spacing: -0.04em;
-  transition: color 0.3s ease;
+  letter-spacing: -0.03em;
+  transition: color 200ms ease;
 }
 
+/* ── Price Badge ────────────────────────────────────────────────── */
 .price-panel {
-  min-width: 220px;
-  padding: 18px 20px;
-  border-radius: 22px;
-  border: 1px solid var(--line-soft);
-  background: var(--price-panel-bg);
-  transition: background 0.3s ease, border-color 0.3s ease;
+  flex-shrink: 0;
+  min-width: 180px;
+  padding: 16px 18px;
+  border-radius: calc(var(--radius) * 1.4);
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in oklab, var(--primary) 12%, transparent),
+      color-mix(in oklab, var(--accent) 60%, transparent)
+    );
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
+}
+
+.price-panel-glow {
+  border-color: color-mix(in oklab, var(--primary) 25%, transparent);
+  animation: glow-pulse 2.4s ease-in-out infinite;
+}
+
+.price-panel-inner {
+  position: relative;
+  z-index: 1;
+  background: radial-gradient(
+    ellipse at top right,
+    color-mix(in oklab, var(--primary) 18%, transparent),
+    transparent 55%
+  );
+  border-radius: calc(var(--radius) * 1.2);
+  padding: 6px;
+  margin: -8px;
+}
+
+.price-label {
+  display: block;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  transition: color 200ms ease;
 }
 
 .price-value {
   display: block;
-  margin-top: 8px;
-  color: var(--accent-color);
-  font-size: clamp(2rem, 4vw, 2.7rem);
+  margin-top: 4px;
+  color: var(--primary);
+  font-family: var(--font-display), var(--font-body),
+    'PingFang SC', 'Noto Sans SC', sans-serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
   font-weight: 800;
   line-height: 1;
   letter-spacing: -0.04em;
   font-variant-numeric: tabular-nums;
-  transition: color 0.3s ease;
+  transition: color 200ms ease;
 }
 
 .price-value.has-value {
@@ -449,58 +712,93 @@
 }
 
 .price-value.awaiting {
-  color: var(--text-muted);
-  font-size: clamp(1.1rem, 2vw, 1.3rem);
+  color: var(--muted-foreground);
+  font-size: 1rem;
+  font-weight: 600;
   letter-spacing: -0.02em;
 }
 
-/* --- Metric Grid --- */
+/* ── Metric Grid ────────────────────────────────────────────────── */
 .results-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
-  margin-bottom: 18px;
 }
 
 .metric-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 14px 16px;
-  border: 1px solid var(--line-soft);
-  border-radius: 18px;
-  background: var(--panel-strong);
-  transition: background 0.3s ease, border-color 0.3s ease;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.4);
+  background: color-mix(in oklab, var(--card) 90%, transparent);
+  transition:
+    transform 200ms ease,
+    background 200ms ease,
+    border-color 200ms ease;
+}
+.metric-card:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklab, var(--primary) 20%, transparent);
 }
 
-.metric-card span {
+.metric-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: calc(var(--radius) * 1.2);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  border: 1px solid color-mix(in oklab, var(--primary) 15%, transparent);
+  color: var(--primary);
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
+}
+.metric-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.metric-body {
+  min-width: 0;
+}
+
+.metric-label {
   display: block;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
   font-size: 10px;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 1.2px;
-  transition: color 0.3s ease;
+  letter-spacing: 0.8px;
+  transition: color 200ms ease;
 }
 
-.metric-card strong {
+.metric-value {
   display: block;
-  margin-top: 6px;
-  color: var(--text-color);
-  font-size: 0.95rem;
+  margin-top: 3px;
+  color: var(--foreground);
+  font-size: 0.9rem;
   font-weight: 700;
-  line-height: 1.45;
+  line-height: 1.35;
   letter-spacing: -0.02em;
-  transition: color 0.3s ease;
+  transition: color 200ms ease;
 }
 
-/* --- Chart Shell --- */
+/* ── Chart Shell ────────────────────────────────────────────────── */
 .chart-shell {
   padding-top: 16px;
-  border-top: 1px solid var(--line-soft);
-  transition: border-color 0.3s ease;
+  border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  transition: border-color 200ms ease;
 }
 
 .chart-header {
   display: grid;
-  gap: 14px;
+  gap: 12px;
   margin-bottom: 14px;
 }
 
@@ -510,21 +808,21 @@
 
 .chart-kicker {
   display: block;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
   font-size: 10px;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 1.3px;
-  transition: color 0.3s ease;
+  letter-spacing: 1.2px;
+  transition: color 200ms ease;
 }
 
 .chart-title {
-  margin: 6px 0 0;
-  color: var(--text-color);
-  font-size: 1.2rem;
+  margin: 4px 0 0;
+  color: var(--foreground);
+  font-size: 1.1rem;
   font-weight: 800;
-  letter-spacing: -0.03em;
-  transition: color 0.3s ease;
+  letter-spacing: -0.02em;
+  transition: color 200ms ease;
 }
 
 .chart-summary-grid {
@@ -534,52 +832,88 @@
 }
 
 .chart-summary-card {
-  min-width: 130px;
   padding: 12px 14px;
-  border: 1px solid var(--line-soft);
-  border-radius: 18px;
-  background: var(--panel-strong);
-  transition: background 0.3s ease, border-color 0.3s ease;
+  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) * 1.4);
+  background: color-mix(in oklab, var(--secondary) 40%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
+}
+.chart-summary-card:hover {
+  border-color: color-mix(in oklab, var(--primary) 20%, transparent);
 }
 
-.chart-summary-card span {
+.chart-summary-label {
   display: block;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
   font-size: 10px;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 1.2px;
-  transition: color 0.3s ease;
+  letter-spacing: 1px;
+  transition: color 200ms ease;
 }
 
-.chart-summary-card strong {
+.chart-summary-value {
   display: block;
-  margin-top: 6px;
-  color: var(--text-color);
+  margin-top: 4px;
+  color: var(--foreground);
   font-size: 1rem;
   font-weight: 800;
   letter-spacing: -0.03em;
   font-variant-numeric: tabular-nums;
-  overflow-wrap: anywhere;
-  transition: color 0.3s ease;
+  transition: color 200ms ease;
 }
 
-.chart-summary-card small {
+.chart-summary-hint {
   display: block;
-  margin-top: 4px;
-  color: var(--text-muted);
+  margin-top: 3px;
+  color: var(--muted-foreground);
   font-size: 9px;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 1.2px;
-  transition: color 0.3s ease;
+  letter-spacing: 1px;
+  transition: color 200ms ease;
 }
 
+.chart-summary-trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 2px;
+  font-size: 10px;
+  font-weight: 800;
+}
+.chart-summary-trend.up {
+  color: var(--chart-4);
+}
+.chart-summary-trend.down {
+  color: var(--chart-5);
+}
+.trend-arrow {
+  width: 12px;
+  height: 12px;
+}
+
+/* ── Chart Frame ────────────────────────────────────────────────── */
 .chart-frame {
-  min-height: 360px;
+  min-height: 340px;
   display: flex;
   align-items: stretch;
   justify-content: center;
+  padding: 8px;
+  border-radius: calc(var(--radius) * 1.4);
+  border: 1px solid color-mix(in oklab, var(--border) 40%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--secondary) 20%, transparent) 0%,
+    color-mix(in oklab, var(--secondary) 5%, transparent) 100%
+  );
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
 }
 
 .chart-frame canvas {
@@ -587,155 +921,182 @@
   height: 100% !important;
 }
 
-/* --- Placeholder State --- */
-.chart-placeholder {
-  align-items: center;
-  border-radius: 24px;
-  border: 1px dashed var(--line-soft);
-  color: var(--text-muted);
-  background: var(--panel-strong);
-  transition: background 0.3s ease, border-color 0.3s ease;
-}
-
-.chart-placeholder-empty {
+/* ── Empty State ────────────────────────────────────────────────── */
+.chart-empty {
   display: grid;
-  gap: 10px;
+  gap: 14px;
   justify-items: start;
+  align-content: center;
+  min-height: 260px;
   padding: 28px;
-  min-height: 220px;
+  border-radius: calc(var(--radius) * 1.4);
+  border: 1px dashed color-mix(in oklab, var(--border) 70%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--muted) 30%, transparent) 0%,
+    transparent 100%
+  );
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
 }
 
-.chart-placeholder-title {
+.empty-heading {
   margin: 0;
-  color: var(--text-color);
-  font-size: 1.35rem;
+  color: var(--foreground);
+  font-size: 1.2rem;
   font-weight: 800;
   letter-spacing: -0.03em;
-  transition: color 0.3s ease;
+  transition: color 200ms ease;
 }
 
-.chart-placeholder-body {
+.empty-body {
   margin: 0;
   max-width: 42ch;
-  color: var(--text-muted);
-  font-size: 0.98rem;
-  line-height: 1.7;
-  transition: color 0.3s ease;
+  color: var(--muted-foreground);
+  font-size: 0.9rem;
+  line-height: 1.65;
+  transition: color 200ms ease;
 }
 
-/* --- Animations --- */
-@keyframes settle {
-  0%   { transform: scale(0.96); opacity: 0.72; }
-  65%  { transform: scale(1.05); opacity: 1; }
-  100% { transform: scale(1);    opacity: 1; }
+.empty-chart-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 80px;
+  animation: empty-float 4s ease-in-out infinite;
 }
 
-@keyframes pulse {
-  from { transform: translateY(0); }
-  to { transform: translateY(-2px); }
+.empty-bar {
+  width: 14px;
+  border-radius: 4px 4px 0 0;
+  background: color-mix(in oklab, var(--primary) 35%, transparent);
+  transition: background 200ms ease;
 }
+
+/* ── Loading skeleton layout ────────────────────────────────────── */
+.skeleton-shell {
+  min-height: 100vh;
+  padding: 20px 24px 32px;
+}
+
+.skeleton-header {
+  height: 44px;
+  border-radius: calc(var(--radius) * 1.4);
+  background: linear-gradient(
+    110deg,
+    var(--secondary) 8%,
+    color-mix(in oklab, var(--secondary) 60%, var(--primary)) 18%,
+    var(--secondary) 33%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.8s ease-in-out infinite;
+  margin-bottom: 20px;
+}
+
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  gap: 20px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.skeleton-card {
+  height: 280px;
+  border-radius: calc(var(--radius) * 1.8);
+  background: linear-gradient(
+    110deg,
+    var(--secondary) 8%,
+    color-mix(in oklab, var(--secondary) 60%, var(--primary)) 18%,
+    var(--secondary) 33%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.8s ease-in-out infinite;
+}
+
+/* ── Animations ─────────────────────────────────────────────────── */
+.animate-fade-in-deep {
+  animation: fade-up-deep 0.5s ease-out both;
+}
+
+.animate-stagger > *:nth-child(1) { animation: fade-up 0.4s ease-out 0.05s both; }
+.animate-stagger > *:nth-child(2) { animation: fade-up 0.4s ease-out 0.12s both; }
+.animate-stagger > *:nth-child(3) { animation: fade-up 0.4s ease-out 0.19s both; }
+.animate-stagger > *:nth-child(4) { animation: fade-up 0.4s ease-out 0.26s both; }
+.animate-stagger > *:nth-child(5) { animation: fade-up 0.4s ease-out 0.33s both; }
+.animate-stagger > *:nth-child(6) { animation: fade-up 0.4s ease-out 0.40s both; }
 
 .loading-pulse {
   display: inline-block;
   animation: pulse 1s ease-in-out infinite alternate;
 }
 
-/* --- Form Fields --- */
-.field-group {
-  display: flex;
-  flex-direction: column;
+/* ── Decorative blobs on intro card ─────────────────────────────── */
+.intro-blob {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
 }
 
-.field-label {
-  display: block;
-  margin-bottom: 8px;
-  color: var(--text-color);
-  font-size: 11px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 1.1px;
-  transition: color 0.3s ease;
+.intro-blob-1 {
+  width: 200px;
+  height: 200px;
+  top: -80px;
+  right: -60px;
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  filter: blur(48px);
 }
 
-.field-select,
-.field-input {
-  width: 100%;
-  padding: 14px 16px;
-  min-height: 52px;
-  border: 1px solid var(--line-soft);
-  border-radius: 16px;
-  background: var(--field-bg);
-  color: var(--text-color);
-  font: inherit;
-  font-weight: 600;
-  font-size: 1rem;
-  outline: none;
-  appearance: none;
-  -webkit-appearance: none;
-  transition: border-color 200ms ease, box-shadow 200ms ease, background 0.3s ease, color 0.3s ease;
+.intro-blob-2 {
+  width: 160px;
+  height: 160px;
+  bottom: -60px;
+  left: -40px;
+  background: color-mix(in oklab, var(--chart-2) 15%, transparent);
+  filter: blur(48px);
 }
 
-.field-select { cursor: pointer; }
-.field-input  { cursor: text; }
-
-.field-select {
-  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%2374685b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 16px center;
-  padding-right: 40px;
-}
-
-.theme-dark .field-select {
-  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%239e998f' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-}
-
-.field-select:hover,
-.field-input:hover {
-  border-color: var(--primary-color);
-}
-
-.field-select:focus-visible,
-.field-input:focus-visible {
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px var(--focus-ring);
-}
-
-.field-input::placeholder {
-  color: var(--text-muted);
-  font-weight: 500;
-}
-
-.field-error {
-  display: block;
-  margin-top: 6px;
-  color: var(--accent-color);
-  font-size: 0.82rem;
-  line-height: 1.4;
-  transition: color 0.3s ease;
-}
-
-/* --- Responsive --- */
-@media (max-width: 1080px) {
-  .layout {
+/* ── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 960px) {
+  .content-grid,
+  .skeleton-grid {
     grid-template-columns: 1fr;
   }
-}
 
-@media (max-width: 900px) {
-  .shell {
-    padding: 18px 14px 30px;
-  }
-
-  .topbar,
-  .results-header {
+  .sticky-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .actions {
+  .header-actions {
     width: 100%;
     display: grid;
     grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .page-surface {
+    padding: 0 14px;
+  }
+
+  .sticky-header {
+    margin: 0 -14px 18px;
+    padding: 12px 14px;
+  }
+
+  .card-inner {
+    padding: 16px;
+  }
+
+  .results-card {
+    padding: 16px;
+  }
+
+  .results-header {
+    flex-direction: column;
   }
 
   .price-panel {
@@ -746,7 +1107,6 @@
   .figure-row,
   .results-grid,
   .button-row,
-  .chart-header,
   .chart-summary-grid {
     grid-template-columns: 1fr;
   }

--- a/src/app/prediction-tool/prediction-tool.component.css
+++ b/src/app/prediction-tool/prediction-tool.component.css
@@ -59,6 +59,11 @@
   transition: background 200ms ease;
 }
 
+.brand-dot-sm {
+  width: 8px;
+  height: 8px;
+}
+
 .header-actions {
   display: flex;
   gap: 8px;
@@ -329,22 +334,11 @@
 }
 
 /* ── Form Shell ─────────────────────────────────────────────────── */
-.form-shell {
-  padding: 20px;
-  border-radius: calc(var(--radius) * 1.4);
-  background: var(--secondary);
-  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
-  transition:
-    background 200ms ease,
-    border-color 200ms ease;
-}
-
 .section-title {
   margin: 0 0 16px;
   color: var(--primary);
   font-size: 1rem;
   font-weight: 800;
-  letter-spacing: -0.02em;
   text-transform: uppercase;
   letter-spacing: 1px;
   transition: color 200ms ease;
@@ -925,6 +919,11 @@
     border-color 200ms ease;
 }
 
+.chart-frame-placeholder {
+  align-items: center;
+  justify-content: center;
+}
+
 .chart-frame canvas {
   width: 100% !important;
   height: 100% !important;
@@ -978,6 +977,7 @@
 
 .empty-bar {
   width: 14px;
+  height: var(--bar-h, 50%);
   border-radius: 4px 4px 0 0;
   background: color-mix(in oklab, var(--primary) 35%, transparent);
   transition: background 200ms ease;
@@ -1041,9 +1041,6 @@
 .animate-stagger > *:nth-child(1) { animation: fade-up 0.4s ease-out 0.05s both; }
 .animate-stagger > *:nth-child(2) { animation: fade-up 0.4s ease-out 0.12s both; }
 .animate-stagger > *:nth-child(3) { animation: fade-up 0.4s ease-out 0.19s both; }
-.animate-stagger > *:nth-child(4) { animation: fade-up 0.4s ease-out 0.26s both; }
-.animate-stagger > *:nth-child(5) { animation: fade-up 0.4s ease-out 0.33s both; }
-.animate-stagger > *:nth-child(6) { animation: fade-up 0.4s ease-out 0.40s both; }
 
 .loading-pulse {
   display: inline-block;

--- a/src/app/prediction-tool/prediction-tool.component.css
+++ b/src/app/prediction-tool/prediction-tool.component.css
@@ -197,6 +197,15 @@
   gap: 18px;
 }
 
+.card-inner-rel {
+  position: relative;
+  z-index: 1;
+}
+
+.panel-spacer {
+  height: 20px;
+}
+
 /* ── Intro Block ────────────────────────────────────────────────── */
 .intro-block {
   display: grid;
@@ -981,6 +990,8 @@
 }
 
 .skeleton-header {
+  max-width: 1280px;
+  margin: 0 auto 20px;
   height: 44px;
   border-radius: calc(var(--radius) * 1.4);
   background: linear-gradient(
@@ -991,7 +1002,6 @@
   );
   background-size: 200% 100%;
   animation: shimmer 1.8s ease-in-out infinite;
-  margin-bottom: 20px;
 }
 
 .skeleton-grid {
@@ -1015,9 +1025,17 @@
   animation: shimmer 1.8s ease-in-out infinite;
 }
 
+.skeleton-card-tall {
+  height: 360px;
+}
+
 /* ── Animations ─────────────────────────────────────────────────── */
 .animate-fade-in-deep {
   animation: fade-up-deep 0.5s ease-out both;
+}
+
+.animate-fade-in-form {
+  animation: fade-up-deep 0.5s ease-out 0.1s both;
 }
 
 .animate-stagger > *:nth-child(1) { animation: fade-up 0.4s ease-out 0.05s both; }

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -165,7 +165,7 @@
                         [placeholder]="t('enter_floor_area')"
                         aria-describedby="floor-area-unit floor-area-error"
                       />
-                      <span id="floor-area-unit" class="unit-tag">m²</span>
+                      <span id="floor-area-unit" class="unit-tag">{{ t('floor_area_unit_short') }}</span>
                     </div>
                     @if (
                       predictionForm.controls.floorAreaSqm.hasError('required') &&
@@ -230,7 +230,7 @@
         </div>
 
         <!-- Right Panel: Results -->
-        <div id="results-anchor">
+        <div #resultsAnchor>
           <section class="results-card" aria-labelledby="results-heading" [attr.aria-busy]="loading() || null">
             <div class="results-header">
               <div class="results-heading-group">

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -235,7 +235,7 @@
             <div class="results-header">
               <div class="results-heading-group">
                 <span class="results-eyebrow">
-                  <span class="brand-dot" aria-hidden="true" style="width:8px;height:8px;"></span>
+                  <span class="brand-dot brand-dot-sm" aria-hidden="true"></span>
                   {{ t('prediction') }}
                 </span>
                 <h2 id="results-heading" class="results-title">{{ t('predicted_price') }}</h2>
@@ -342,19 +342,19 @@
                     ></canvas>
                   </div>
                 } @else {
-                  <div class="chart-frame" style="align-items:center;justify-content:center;">
+                  <div class="chart-frame chart-frame-placeholder">
                     <span class="chart-summary-label">{{ t('loading_chart') }}</span>
                   </div>
                 }
               } @else {
                 <div class="chart-empty">
                   <div class="empty-chart-bars" aria-hidden="true">
-                    <div class="empty-bar" style="height:35%;"></div>
-                    <div class="empty-bar" style="height:55%;"></div>
-                    <div class="empty-bar" style="height:85%;"></div>
-                    <div class="empty-bar" style="height:45%;"></div>
-                    <div class="empty-bar" style="height:70%;"></div>
-                    <div class="empty-bar" style="height:30%;"></div>
+                    <div class="empty-bar" style="--bar-h:35%"></div>
+                    <div class="empty-bar" style="--bar-h:55%"></div>
+                    <div class="empty-bar" style="--bar-h:85%"></div>
+                    <div class="empty-bar" style="--bar-h:45%"></div>
+                    <div class="empty-bar" style="--bar-h:70%"></div>
+                    <div class="empty-bar" style="--bar-h:30%"></div>
                   </div>
                   <h3 class="empty-heading">{{ t('results_placeholder_title') }}</h3>
                   <p class="empty-body">{{ t('results_placeholder_body') }}</p>

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -1,10 +1,10 @@
 @if (!mounted()) {
   <!-- Skeleton loading state -->
   <main class="skeleton-shell" aria-busy="true">
-    <div class="skeleton-header" style="max-width:1280px;margin:0 auto 20px;"></div>
+    <div class="skeleton-header"></div>
     <div class="skeleton-grid">
       <div class="skeleton-card"></div>
-      <div class="skeleton-card" style="height:360px;"></div>
+      <div class="skeleton-card skeleton-card-tall"></div>
     </div>
   </main>
 } @else {
@@ -23,7 +23,7 @@
             class="btn-outline"
             (click)="toggleLanguage()"
           >
-            {{ lang() === 'zh' ? 'English' : '中文' }}
+            {{ lang() === 'zh' ? t('language_label_en') : t('language_label_zh') }}
           </button>
           <button
             type="button"
@@ -50,7 +50,7 @@
             <div class="intro-blob intro-blob-1" aria-hidden="true"></div>
             <div class="intro-blob intro-blob-2" aria-hidden="true"></div>
 
-            <div class="card-inner" style="position:relative;z-index:1;">
+            <div class="card-inner card-inner-rel">
               <div class="intro-block">
                 <h1 id="intro-heading" class="headline" [class.headline-cjk]="lang() === 'zh'">
                   {{ t('price_prediction') }}
@@ -94,10 +94,10 @@
             </div>
           </section>
 
-          <div style="height: 20px;" aria-hidden="true"></div>
+          <div class="panel-spacer" aria-hidden="true"></div>
 
           <!-- Form Card -->
-          <section class="panel-card panel-card-accent animate-fade-in-deep" aria-labelledby="form-heading" style="animation-delay:0.1s;">
+          <section class="panel-card panel-card-accent animate-fade-in-form" aria-labelledby="form-heading">
             <div class="card-inner">
               <h2 id="form-heading" class="section-title">{{ t('prediction_form') }}</h2>
 

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -1,70 +1,105 @@
-<main
-  class="shell"
-  [class.theme-dark]="darkMode()"
-  [class.theme-light]="!darkMode()"
->
-  <div class="surface">
-    <div class="topbar">
-      <div class="pill">{{ t('intro_eyebrow') }}</div>
-
-      <div class="actions">
-        <button
-          type="button"
-          class="ghost-btn"
-          [attr.aria-pressed]="darkMode()"
-          (click)="toggleTheme()"
-        >
-          {{ darkMode() ? t('switch_to_light') : t('switch_to_dark') }}
-        </button>
-        <button
-          type="button"
-          class="ghost-btn"
-          (click)="toggleLanguage()"
-        >
-          {{ t('switch_language') }}
-        </button>
-      </div>
+@if (!mounted()) {
+  <!-- Skeleton loading state -->
+  <main class="skeleton-shell" aria-busy="true">
+    <div class="skeleton-header" style="max-width:1280px;margin:0 auto 20px;"></div>
+    <div class="skeleton-grid">
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card" style="height:360px;"></div>
     </div>
+  </main>
+} @else {
+  <main class="shell" [class.theme-ready]="mounted()">
+    <div class="page-surface">
+      <!-- ═══ Sticky Header ═══ -->
+      <header class="sticky-header">
+        <div class="brand-badge">
+          <span class="brand-dot" aria-hidden="true"></span>
+          {{ t('intro_eyebrow') }}
+        </div>
 
-    <div class="layout">
-      <section class="panel">
-        <div class="card">
-          <div class="card-inner">
-            <div class="intro-block">
-              <h1
-                class="headline"
-                [class.headline-cjk]="lang() === 'zh'"
-              >
-                {{ t('price_prediction') }}
-              </h1>
-              <p class="lead">{{ t('intro_blurb') }}</p>
+        <div class="header-actions">
+          <button
+            type="button"
+            class="btn-outline"
+            (click)="toggleLanguage()"
+          >
+            {{ lang() === 'zh' ? 'English' : '中文' }}
+          </button>
+          <button
+            type="button"
+            class="btn-icon"
+            [attr.aria-label]="darkMode() ? t('switch_to_light_mode') : t('switch_to_dark_mode')"
+            [attr.aria-pressed]="darkMode()"
+            (click)="toggleTheme()"
+          >
+            @if (darkMode()) {
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
+            } @else {
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+            }
+          </button>
+        </div>
+      </header>
 
-              <div class="figure-row">
-                <div class="figure">
-                  <span class="figure-label">{{ t('ml_model') }}</span>
-                  <strong class="figure-value">{{
-                    mlModels.length.toString().padStart(2, '0')
-                  }}</strong>
+      <!-- ═══ Content Grid ═══ -->
+      <div class="content-grid">
+        <!-- Left Panel: Intro + Form -->
+        <div>
+          <!-- Intro Card -->
+          <section class="panel-card panel-card-accent animate-fade-in-deep" aria-labelledby="intro-heading">
+            <div class="intro-blob intro-blob-1" aria-hidden="true"></div>
+            <div class="intro-blob intro-blob-2" aria-hidden="true"></div>
+
+            <div class="card-inner" style="position:relative;z-index:1;">
+              <div class="intro-block">
+                <h1 id="intro-heading" class="headline" [class.headline-cjk]="lang() === 'zh'">
+                  {{ t('price_prediction') }}
+                </h1>
+                <p class="lead">{{ t('intro_blurb') }}</p>
+
+                <div class="figure-row animate-stagger">
+                  <div class="stat-tile">
+                    <div class="stat-tile-icon" aria-hidden="true">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2"/><line x1="12" y1="22" x2="12" y2="15.5"/><polyline points="22 8.5 12 15.5 2 8.5"/></svg>
+                    </div>
+                    <div class="stat-tile-text">
+                      <span class="stat-tile-label">{{ t('models_count') }}</span>
+                      <strong class="stat-tile-value">{{ mlModels.length }}</strong>
+                    </div>
+                  </div>
+
+                  <div class="stat-tile">
+                    <div class="stat-tile-icon" aria-hidden="true">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                    </div>
+                    <div class="stat-tile-text">
+                      <span class="stat-tile-label">{{ t('towns_count') }}</span>
+                      <strong class="stat-tile-value">{{ towns.length }}</strong>
+                    </div>
+                  </div>
+
+                  <div class="stat-tile">
+                    <div class="stat-tile-icon" aria-hidden="true">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                    </div>
+                    <div class="stat-tile-text">
+                      <span class="stat-tile-label">{{ t('flat_types_count') }}</span>
+                      <strong class="stat-tile-value">{{ flatModels.length }}</strong>
+                    </div>
+                  </div>
                 </div>
-                <div class="figure">
-                  <span class="figure-label">{{ t('town') }}</span>
-                  <strong class="figure-value">{{
-                    towns.length.toString().padStart(2, '0')
-                  }}</strong>
-                </div>
-                <div class="figure">
-                  <span class="figure-label">{{ t('flat_model') }}</span>
-                  <strong class="figure-value">{{
-                    flatModels.length.toString().padStart(2, '0')
-                  }}</strong>
-                </div>
+
+                <p class="caption">{{ t('intro_caption') }}</p>
               </div>
-
-              <p class="caption">{{ t('intro_caption') }}</p>
             </div>
+          </section>
 
-            <div class="form-shell">
-              <h2 class="section-title">{{ t('prediction_form') }}</h2>
+          <div style="height: 20px;" aria-hidden="true"></div>
+
+          <!-- Form Card -->
+          <section class="panel-card panel-card-accent animate-fade-in-deep" aria-labelledby="form-heading" style="animation-delay:0.1s;">
+            <div class="card-inner">
+              <h2 id="form-heading" class="section-title">{{ t('prediction_form') }}</h2>
 
               <form
                 [formGroup]="predictionForm"
@@ -130,7 +165,7 @@
                         [placeholder]="t('enter_floor_area')"
                         aria-describedby="floor-area-unit floor-area-error"
                       />
-                      <span id="floor-area-unit" class="unit-tag">sqm</span>
+                      <span id="floor-area-unit" class="unit-tag">m²</span>
                     </div>
                     @if (
                       predictionForm.controls.floorAreaSqm.hasError('required') &&
@@ -181,114 +216,154 @@
                 </div>
               </form>
 
+              @if (loading()) {
+                <div class="progress-track" role="progressbar" aria-label="Loading prediction">
+                  <div class="progress-bar"></div>
+                </div>
+              }
+
               @if (errorMessage()) {
-                <p class="error-banner">{{ errorMessage() }}</p>
+                <p class="error-display" role="alert">{{ errorMessage() }}</p>
               }
             </div>
-          </div>
+          </section>
         </div>
-      </section>
 
-      <section class="results-panel">
-        <div class="results-card">
-          <div class="results-header">
-            <div>
-              <span class="results-label">{{ t('predicted_trends') }}</span>
-              <h2 class="results-title">{{ t('predicted_price') }}</h2>
+        <!-- Right Panel: Results -->
+        <div id="results-anchor">
+          <section class="results-card" aria-labelledby="results-heading" [attr.aria-busy]="loading() || null">
+            <div class="results-header">
+              <div class="results-heading-group">
+                <span class="results-eyebrow">
+                  <span class="brand-dot" aria-hidden="true" style="width:8px;height:8px;"></span>
+                  {{ t('prediction') }}
+                </span>
+                <h2 id="results-heading" class="results-title">{{ t('predicted_price') }}</h2>
+              </div>
+
+              <div
+                class="price-panel"
+                [class.price-panel-glow]="hasPrediction()"
+              >
+                <div class="price-panel-inner">
+                  <span class="price-label">{{ t('prediction') }}</span>
+                  @if (hasPrediction()) {
+                    <strong class="price-value has-value" aria-live="polite">
+                      {{ formatCurrency(predictedPrice()) }}
+                    </strong>
+                  } @else if (loading()) {
+                    <strong class="price-value awaiting">
+                      <span class="loading-pulse">{{ t('predicting') }}</span>
+                    </strong>
+                  } @else {
+                    <strong class="price-value awaiting">
+                      {{ t('awaiting_prediction') }}
+                    </strong>
+                  }
+                </div>
+              </div>
             </div>
 
-            <div class="price-panel">
-              <span class="results-label">{{ t('prediction') }}</span>
+            <!-- Summary metric cards -->
+            <div class="results-grid">
+              <div class="metric-card">
+                <div class="metric-icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2"/><line x1="12" y1="22" x2="12" y2="15.5"/><polyline points="22 8.5 12 15.5 2 8.5"/></svg>
+                </div>
+                <div class="metric-body">
+                  <span class="metric-label">{{ t('ml_model') }}</span>
+                  <strong class="metric-value">{{ tOption('ml_models', summaryValues().mlModel) }}</strong>
+                </div>
+              </div>
+
+              <div class="metric-card">
+                <div class="metric-icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                </div>
+                <div class="metric-body">
+                  <span class="metric-label">{{ t('town') }}</span>
+                  <strong class="metric-value">{{ tOption('towns', summaryValues().town) }}</strong>
+                </div>
+              </div>
+
+              <div class="metric-card">
+                <div class="metric-icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                </div>
+                <div class="metric-body">
+                  <span class="metric-label">{{ t('lease_commence_date') }}</span>
+                  <strong class="metric-value">{{ summaryValues().leaseCommenceYear }}</strong>
+                </div>
+              </div>
+            </div>
+
+            <!-- Chart area -->
+            <div class="chart-shell">
               @if (hasPrediction()) {
-                <strong class="price-value has-value" aria-live="polite">{{
-                  formatCurrency(predictedPrice())
-                }}</strong>
+                <div class="chart-header">
+                  <div class="chart-copy">
+                    <span class="chart-kicker">{{ t('predicted_trends') }}</span>
+                    <h3 class="chart-title">{{ t('chart_story_title') }}</h3>
+                  </div>
+
+                  <div class="chart-summary-grid">
+                    <div class="chart-summary-card">
+                      <span class="chart-summary-label">{{ t('chart_latest') }}</span>
+                      <strong class="chart-summary-value">{{ formatCurrency(chartMetrics().latestValue) }}</strong>
+                    </div>
+                    <div class="chart-summary-card">
+                      <span class="chart-summary-label">{{ t('chart_range') }}</span>
+                      <strong class="chart-summary-value">{{ formatCurrencyRange(chartMetrics().lowValue, chartMetrics().peakValue) }}</strong>
+                    </div>
+                    <div class="chart-summary-card">
+                      <span class="chart-summary-label">{{ t('chart_delta') }}</span>
+                      <strong class="chart-summary-value">
+                        {{ formatDeltaCurrency(chartMetrics().deltaValue) }}
+                        <span class="chart-summary-trend" [class.up]="chartMetrics().deltaValue >= 0" [class.down]="chartMetrics().deltaValue < 0">
+                          @if (chartMetrics().deltaValue >= 0) {
+                            <svg class="trend-arrow" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
+                          } @else {
+                            <svg class="trend-arrow" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                          }
+                        </span>
+                      </strong>
+                      <span class="chart-summary-hint">{{ t('vs_12m_ago') }}</span>
+                    </div>
+                  </div>
+                </div>
+
+                @if (isBrowser) {
+                  <div class="chart-frame">
+                    <canvas
+                      baseChart
+                      [type]="'line'"
+                      [data]="chartData()"
+                      [options]="chartOptions()"
+                    ></canvas>
+                  </div>
+                } @else {
+                  <div class="chart-frame" style="align-items:center;justify-content:center;">
+                    <span class="chart-summary-label">{{ t('loading_chart') }}</span>
+                  </div>
+                }
               } @else {
-                <strong class="price-value awaiting">{{
-                  t('awaiting_prediction')
-                }}</strong>
+                <div class="chart-empty">
+                  <div class="empty-chart-bars" aria-hidden="true">
+                    <div class="empty-bar" style="height:35%;"></div>
+                    <div class="empty-bar" style="height:55%;"></div>
+                    <div class="empty-bar" style="height:85%;"></div>
+                    <div class="empty-bar" style="height:45%;"></div>
+                    <div class="empty-bar" style="height:70%;"></div>
+                    <div class="empty-bar" style="height:30%;"></div>
+                  </div>
+                  <h3 class="empty-heading">{{ t('results_placeholder_title') }}</h3>
+                  <p class="empty-body">{{ t('results_placeholder_body') }}</p>
+                </div>
               }
             </div>
-          </div>
-
-          <div class="results-grid">
-            <div class="metric-card">
-              <span>{{ t('ml_model') }}</span>
-              <strong>{{
-                tOption('ml_models', summaryValues().mlModel)
-              }}</strong>
-            </div>
-            <div class="metric-card">
-              <span>{{ t('town') }}</span>
-              <strong>{{ tOption('towns', summaryValues().town) }}</strong>
-            </div>
-            <div class="metric-card">
-              <span>{{ t('lease_commence_date') }}</span>
-              <strong>{{ summaryValues().leaseCommenceYear }}</strong>
-            </div>
-          </div>
-
-          <div class="chart-shell">
-            @if (hasPrediction()) {
-              <div class="chart-header">
-                <div class="chart-copy">
-                  <span class="chart-kicker">{{ t('predicted_trends') }}</span>
-                  <h3 class="chart-title">{{ t('chart_story_title') }}</h3>
-                </div>
-
-                <div class="chart-summary-grid">
-                  <div class="chart-summary-card">
-                    <span>{{ t('chart_latest') }}</span>
-                    <strong>{{
-                      formatCurrency(chartMetrics().latestValue)
-                    }}</strong>
-                  </div>
-                  <div class="chart-summary-card">
-                    <span>{{ t('chart_range') }}</span>
-                    <strong>{{
-                      formatCurrencyRange(
-                        chartMetrics().lowValue,
-                        chartMetrics().peakValue
-                      )
-                    }}</strong>
-                  </div>
-                  <div class="chart-summary-card">
-                    <span>{{ t('chart_delta') }}</span>
-                    <strong>{{
-                      formatDeltaCurrency(chartMetrics().deltaValue)
-                    }}</strong>
-                    <small>{{ t('vs_12m_ago') }}</small>
-                  </div>
-                </div>
-              </div>
-
-              @if (isBrowser) {
-                <div class="chart-frame">
-                  <canvas
-                    baseChart
-                    [type]="'line'"
-                    [data]="chartData()"
-                    [options]="chartOptions()"
-                  ></canvas>
-                </div>
-              } @else {
-                <div class="chart-frame chart-placeholder">
-                  {{ t('loading_chart') }}
-                </div>
-              }
-            } @else {
-              <div class="chart-placeholder chart-placeholder-empty">
-                <h3 class="chart-placeholder-title">
-                  {{ t('results_placeholder_title') }}
-                </h3>
-                <p class="chart-placeholder-body">
-                  {{ t('results_placeholder_body') }}
-                </p>
-              </div>
-            }
-          </div>
+          </section>
         </div>
-      </section>
+      </div>
     </div>
-  </div>
-</main>
+  </main>
+}

--- a/src/app/prediction-tool/prediction-tool.component.spec.ts
+++ b/src/app/prediction-tool/prediction-tool.component.spec.ts
@@ -28,9 +28,9 @@ describe('PredictionToolComponent', () => {
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
 
-    expect(compiled.querySelector('.chart-placeholder-title')?.textContent)
+    expect(compiled.querySelector('.empty-heading')?.textContent)
       .toContain('Run a scenario');
-    expect(compiled.querySelector('.price-value-placeholder')?.textContent)
+    expect(compiled.querySelector('.price-value.awaiting')?.textContent)
       .toContain('Awaiting prediction');
   });
 });

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -365,9 +365,9 @@ export class PredictionToolComponent implements OnInit {
       this.chart?.update();
 
       if (this.isBrowser) {
-        setTimeout(() => {
+        requestAnimationFrame(() => {
           this.resultsAnchor?.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        }, 0);
+        });
       }
     } catch (error: unknown) {
       console.error('Prediction request failed', {
@@ -661,14 +661,12 @@ function readCssVar(name: string, doc: Document): string {
   return getComputedStyle(doc.body).getPropertyValue(name).trim();
 }
 
-function colorWithAlpha(hex: string, alpha: number): string {
-  if (!hex) return '';
-  const h = hex.replace('#', '');
-  const rr = h.length === 3 ? h[0] + h[0] + h[1] + h[1] + h[2] + h[2] : h;
-  const r = parseInt(rr.slice(0, 2), 16);
-  const g = parseInt(rr.slice(2, 4), 16);
-  const b = parseInt(rr.slice(4, 6), 16);
-  if (Number.isNaN(r)) return '';
+function colorWithAlpha(color: string, alpha: number): string {
+  if (!color) return '';
+  const digits = color.match(/\d+/g);
+  if (!digits || digits.length < 3) return '';
+  const [r, g, b] = digits.map(Number);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return '';
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -157,27 +157,31 @@ export class PredictionToolComponent implements OnInit {
 
   protected readonly chartData = computed<
     ChartConfiguration<'line'>['data']
-  >(() => ({
-    labels: this.trendData().map((point) => point.label),
-    datasets: [
-      {
-        data: this.trendData().map((point) => point.value),
-        label: this.t('predicted_price'),
-        borderColor: readCssVar('--primary'),
-        backgroundColor: readCssVar('--chart-fill'),
-        pointBackgroundColor: readCssVar('--primary'),
-        pointHoverBackgroundColor: readCssVar('--primary'),
-        pointHoverBorderColor: readCssVar('--card'),
-        fill: true,
-        tension: 0.35,
-        borderWidth: 3
-      }
-    ]
-  }));
+  >(() => {
+    void this.darkMode();
+    return {
+      labels: this.trendData().map((point) => point.label),
+      datasets: [
+        {
+          data: this.trendData().map((point) => point.value),
+          label: this.t('predicted_price'),
+          borderColor: readCssVar('--primary'),
+          backgroundColor: readCssVar('--chart-fill'),
+          pointBackgroundColor: readCssVar('--primary'),
+          pointHoverBackgroundColor: readCssVar('--primary'),
+          pointHoverBorderColor: readCssVar('--card'),
+          fill: true,
+          tension: 0.35,
+          borderWidth: 3
+        }
+      ]
+    };
+  });
 
   protected readonly chartOptions = computed<
     ChartConfiguration<'line'>['options']
   >(() => {
+    void this.darkMode();
     const labelColor = readCssVar('--muted-foreground');
     const panelColor = readCssVar('--popover');
     const tooltipBorder = colorWithAlpha(readCssVar('--primary'), 0.16);

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -406,6 +406,7 @@ export class PredictionToolComponent implements OnInit {
     }
 
     this.syncDocumentState();
+    this.chart?.update();
   }
 
   protected toggleLanguage(): void {
@@ -657,7 +658,7 @@ function formatCurrency(value: number): string {
 }
 
 function readCssVar(name: string, doc: Document): string {
-  return getComputedStyle(doc.documentElement).getPropertyValue(name).trim();
+  return getComputedStyle(doc.body).getPropertyValue(name).trim();
 }
 
 function colorWithAlpha(hex: string, alpha: number): string {

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -662,12 +662,30 @@ function readCssVar(name: string, doc: Document): string {
 }
 
 function colorWithAlpha(color: string, alpha: number): string {
-  if (!color) return '';
-  const digits = color.match(/\d+/g);
-  if (!digits || digits.length < 3) return '';
-  const [r, g, b] = digits.map(Number);
-  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return '';
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  const trimmed = color.trim();
+  if (!trimmed) return '';
+
+  if (trimmed.startsWith('rgb')) {
+    const match = trimmed.match(/\d+/g);
+    if (!match || match.length < 3) return '';
+    const [r, g, b] = match.map(Number);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return '';
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  if (trimmed.startsWith('#')) {
+    const hex = trimmed.slice(1);
+    const full = hex.length === 3
+      ? hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+      : hex;
+    const r = parseInt(full.slice(0, 2), 16);
+    const g = parseInt(full.slice(2, 4), 16);
+    const b = parseInt(full.slice(4, 6), 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return '';
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  return '';
 }
 
 function formatCompactCurrency(value: number): string {

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -163,13 +163,11 @@ export class PredictionToolComponent implements OnInit {
       {
         data: this.trendData().map((point) => point.value),
         label: this.t('predicted_price'),
-        borderColor: this.darkMode() ? '#818cf8' : '#4f46e5',
-        backgroundColor: this.darkMode()
-          ? 'rgba(129, 140, 248, 0.26)'
-          : 'rgba(79, 70, 229, 0.18)',
-        pointBackgroundColor: this.darkMode() ? '#818cf8' : '#4f46e5',
-        pointHoverBackgroundColor: this.darkMode() ? '#818cf8' : '#4f46e5',
-        pointHoverBorderColor: this.darkMode() ? '#0f172a' : '#ffffff',
+        borderColor: readCssVar('--primary'),
+        backgroundColor: readCssVar('--chart-fill'),
+        pointBackgroundColor: readCssVar('--primary'),
+        pointHoverBackgroundColor: readCssVar('--primary'),
+        pointHoverBorderColor: readCssVar('--card'),
         fill: true,
         tension: 0.35,
         borderWidth: 3
@@ -180,15 +178,10 @@ export class PredictionToolComponent implements OnInit {
   protected readonly chartOptions = computed<
     ChartConfiguration<'line'>['options']
   >(() => {
-    const darkMode = this.darkMode();
-    const labelColor = darkMode ? '#94a3b8' : '#64748b';
-    const panelColor = darkMode ? '#161929' : '#ffffff';
-    const tooltipBorder = darkMode
-      ? 'rgba(129, 140, 248, 0.16)'
-      : 'rgba(79, 70, 229, 0.14)';
-    const gridColor = darkMode
-      ? 'rgba(255,255,255,0.08)'
-      : 'rgba(15, 23, 42, 0.08)';
+    const labelColor = readCssVar('--muted-foreground');
+    const panelColor = readCssVar('--popover');
+    const tooltipBorder = colorWithAlpha(readCssVar('--primary'), 0.16);
+    const gridColor = colorWithAlpha(readCssVar('--foreground'), 0.08);
 
     return {
       responsive: true,
@@ -203,8 +196,8 @@ export class PredictionToolComponent implements OnInit {
         tooltip: {
           displayColors: false,
           backgroundColor: panelColor,
-          titleColor: darkMode ? '#f2ede6' : '#1f2328',
-          bodyColor: darkMode ? '#f2ede6' : '#1f2328',
+          titleColor: readCssVar('--foreground'),
+          bodyColor: readCssVar('--foreground'),
           borderColor: tooltipBorder,
           borderWidth: 1,
           callbacks: {
@@ -369,7 +362,7 @@ export class PredictionToolComponent implements OnInit {
         setTimeout(() => {
           const anchor = this.document.getElementById('results-anchor');
           anchor?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        }, 100);
+        }, 0);
       }
     } catch (error: unknown) {
       console.error('Prediction request failed', {
@@ -656,6 +649,20 @@ function roundValue(value: number): number {
 
 function formatCurrency(value: number): string {
   return `$${sanitizeCurrencyValue(value).toLocaleString()}`;
+}
+
+function readCssVar(name: string): string {
+  if (typeof document === 'undefined') return '';
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function colorWithAlpha(hex: string, alpha: number): string {
+  if (!hex) return '';
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  if (Number.isNaN(r)) return '';
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
 function formatCompactCurrency(value: number): string {

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -120,6 +120,7 @@ export class PredictionToolComponent implements OnInit {
     (_, index) => MAX_YEAR - index
   );
 
+  protected readonly mounted = signal(false);
   protected readonly loading = signal(false);
   protected readonly darkMode = signal(false);
   protected readonly errorMessage = signal('');
@@ -162,13 +163,13 @@ export class PredictionToolComponent implements OnInit {
       {
         data: this.trendData().map((point) => point.value),
         label: this.t('predicted_price'),
-        borderColor: this.darkMode() ? '#cf8b60' : '#af6542',
+        borderColor: this.darkMode() ? '#818cf8' : '#4f46e5',
         backgroundColor: this.darkMode()
-          ? 'rgba(207, 139, 96, 0.26)'
-          : 'rgba(175, 101, 66, 0.18)',
-        pointBackgroundColor: this.darkMode() ? '#cf8b60' : '#af6542',
-        pointHoverBackgroundColor: this.darkMode() ? '#cf8b60' : '#af6542',
-        pointHoverBorderColor: this.darkMode() ? '#0f1821' : '#fffaf4',
+          ? 'rgba(129, 140, 248, 0.26)'
+          : 'rgba(79, 70, 229, 0.18)',
+        pointBackgroundColor: this.darkMode() ? '#818cf8' : '#4f46e5',
+        pointHoverBackgroundColor: this.darkMode() ? '#818cf8' : '#4f46e5',
+        pointHoverBorderColor: this.darkMode() ? '#0f172a' : '#ffffff',
         fill: true,
         tension: 0.35,
         borderWidth: 3
@@ -180,14 +181,14 @@ export class PredictionToolComponent implements OnInit {
     ChartConfiguration<'line'>['options']
   >(() => {
     const darkMode = this.darkMode();
-    const labelColor = darkMode ? '#9e998f' : '#74685b';
-    const panelColor = darkMode ? '#13202b' : '#fffaf4';
+    const labelColor = darkMode ? '#94a3b8' : '#64748b';
+    const panelColor = darkMode ? '#161929' : '#ffffff';
     const tooltipBorder = darkMode
-      ? 'rgba(141, 174, 193, 0.16)'
-      : 'rgba(116, 92, 68, 0.14)';
+      ? 'rgba(129, 140, 248, 0.16)'
+      : 'rgba(79, 70, 229, 0.14)';
     const gridColor = darkMode
       ? 'rgba(255,255,255,0.08)'
-      : 'rgba(31, 35, 40, 0.08)';
+      : 'rgba(15, 23, 42, 0.08)';
 
     return {
       responsive: true,
@@ -277,6 +278,12 @@ export class PredictionToolComponent implements OnInit {
     this.syncSummaryWithForm();
     this.syncDocumentState();
 
+    this.mounted.set(true);
+
+    if (this.isBrowser) {
+      this.document.body.classList.add('theme-ready');
+    }
+
     this.predictionForm.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((partialValue) => {
@@ -357,6 +364,13 @@ export class PredictionToolComponent implements OnInit {
       this.hasPrediction.set(true);
       this.trendData.set(normalizeTrendData(serverData));
       this.chart?.update();
+
+      if (this.isBrowser) {
+        setTimeout(() => {
+          const anchor = this.document.getElementById('results-anchor');
+          anchor?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }, 100);
+      }
     } catch (error: unknown) {
       console.error('Prediction request failed', {
         error,

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
   OnInit,
   PLATFORM_ID,
   ViewChild,
@@ -109,6 +110,7 @@ export class PredictionToolComponent implements OnInit {
   private readonly translationService = inject(TranslationService);
 
   @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+  @ViewChild('resultsAnchor') resultsAnchor?: ElementRef<HTMLElement>;
 
   protected readonly lang = this.translationService.lang;
   protected readonly mlModels = ml_model_list;
@@ -165,11 +167,11 @@ export class PredictionToolComponent implements OnInit {
         {
           data: this.trendData().map((point) => point.value),
           label: this.t('predicted_price'),
-          borderColor: readCssVar('--primary'),
-          backgroundColor: readCssVar('--chart-fill'),
-          pointBackgroundColor: readCssVar('--primary'),
-          pointHoverBackgroundColor: readCssVar('--primary'),
-          pointHoverBorderColor: readCssVar('--card'),
+          borderColor: readCssVar('--primary', this.document),
+          backgroundColor: readCssVar('--chart-fill', this.document),
+          pointBackgroundColor: readCssVar('--primary', this.document),
+          pointHoverBackgroundColor: readCssVar('--primary', this.document),
+          pointHoverBorderColor: readCssVar('--card', this.document),
           fill: true,
           tension: 0.35,
           borderWidth: 3
@@ -182,10 +184,10 @@ export class PredictionToolComponent implements OnInit {
     ChartConfiguration<'line'>['options']
   >(() => {
     void this.darkMode();
-    const labelColor = readCssVar('--muted-foreground');
-    const panelColor = readCssVar('--popover');
-    const tooltipBorder = colorWithAlpha(readCssVar('--primary'), 0.16);
-    const gridColor = colorWithAlpha(readCssVar('--foreground'), 0.08);
+    const labelColor = readCssVar('--muted-foreground', this.document);
+    const panelColor = readCssVar('--popover', this.document);
+    const tooltipBorder = colorWithAlpha(readCssVar('--primary', this.document), 0.16);
+    const gridColor = colorWithAlpha(readCssVar('--foreground', this.document), 0.08);
 
     return {
       responsive: true,
@@ -200,8 +202,8 @@ export class PredictionToolComponent implements OnInit {
         tooltip: {
           displayColors: false,
           backgroundColor: panelColor,
-          titleColor: readCssVar('--foreground'),
-          bodyColor: readCssVar('--foreground'),
+          titleColor: readCssVar('--foreground', this.document),
+          bodyColor: readCssVar('--foreground', this.document),
           borderColor: tooltipBorder,
           borderWidth: 1,
           callbacks: {
@@ -364,8 +366,7 @@ export class PredictionToolComponent implements OnInit {
 
       if (this.isBrowser) {
         setTimeout(() => {
-          const anchor = this.document.getElementById('results-anchor');
-          anchor?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          this.resultsAnchor?.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }, 0);
       }
     } catch (error: unknown) {
@@ -655,16 +656,17 @@ function formatCurrency(value: number): string {
   return `$${sanitizeCurrencyValue(value).toLocaleString()}`;
 }
 
-function readCssVar(name: string): string {
-  if (typeof document === 'undefined') return '';
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+function readCssVar(name: string, doc: Document): string {
+  return getComputedStyle(doc.documentElement).getPropertyValue(name).trim();
 }
 
 function colorWithAlpha(hex: string, alpha: number): string {
   if (!hex) return '';
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  const h = hex.replace('#', '');
+  const rr = h.length === 3 ? h[0] + h[0] + h[1] + h[1] + h[2] + h[2] : h;
+  const r = parseInt(rr.slice(0, 2), 16);
+  const g = parseInt(rr.slice(2, 4), 16);
+  const b = parseInt(rr.slice(4, 6), 16);
   if (Number.isNaN(r)) return '';
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }

--- a/src/app/services/i18n.resources.ts
+++ b/src/app/services/i18n.resources.ts
@@ -21,6 +21,8 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       switch_to_light: 'Light Mode',
       switch_to_light_mode: 'Switch to light mode',
       switch_to_dark_mode: 'Switch to dark mode',
+      language_label_en: 'English',
+      language_label_zh: '中文',
       price_prediction: 'Price\nPrediction',
       intro_eyebrow: 'Singapore HDB resale estimator',
       intro_blurb:
@@ -152,6 +154,8 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       switch_to_light: '浅色模式',
       switch_to_light_mode: '切换到浅色模式',
       switch_to_dark_mode: '切换到深色模式',
+      language_label_en: 'English',
+      language_label_zh: '中文',
       price_prediction: '价格\n预测',
       intro_eyebrow: '新加坡组屋转售价估算器',
       intro_blurb:

--- a/src/app/services/i18n.resources.ts
+++ b/src/app/services/i18n.resources.ts
@@ -60,6 +60,7 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       error_form_restore_failed:
         'Saved form data was invalid and has been reset.',
       floor_area_unit: 'Square metres (m²)',
+      floor_area_unit_short: 'm²',
       prediction_success:
         'Prediction complete! Scroll down to view results.',
       models_count: 'Models',
@@ -187,6 +188,7 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
         '服务器返回的价格无法显示。请尝试其他输入或模型。',
       error_form_restore_failed: '已保存的表单数据无效，已重置。',
       floor_area_unit: '平方米 (m²)',
+      floor_area_unit_short: 'm²',
       prediction_success: '预测完成！向下滚动查看结果。',
       models_count: '模型',
       towns_count: '城镇',

--- a/src/app/services/i18n.resources.ts
+++ b/src/app/services/i18n.resources.ts
@@ -51,18 +51,7 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       results_placeholder_title: 'Run a scenario to generate a forecast',
       results_placeholder_body:
         'Choose a model, adjust the flat details, and submit the form to see the projected resale price and 12-month trend.',
-      stat_models_hint:
-        'Machine learning models trained on HDB resale transactions.',
-      stat_towns_hint: 'Singapore towns covered in the resale dataset.',
-      stat_types_hint: 'HDB flat model types used as prediction inputs.',
-      error_invalid_prediction:
-        'The server returned prices we could not display. Try different inputs or a model.',
-      error_form_restore_failed:
-        'Saved form data was invalid and has been reset.',
-      floor_area_unit: 'Square metres (m²)',
       floor_area_unit_short: 'm²',
-      prediction_success:
-        'Prediction complete! Scroll down to view results.',
       models_count: 'Models',
       towns_count: 'Towns',
       flat_types_count: 'Flat Types'
@@ -181,15 +170,7 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       results_placeholder_title: '提交一个情境后即可生成预测',
       results_placeholder_body:
         '选择模型并调整房屋资料后提交表单，即可查看预测转售价与过去12个月趋势。',
-      stat_models_hint: '基于组屋转售成交数据训练的机器学习模型。',
-      stat_towns_hint: '数据集中涵盖的新加坡城镇。',
-      stat_types_hint: '用作预测输入的组屋房型。',
-      error_invalid_prediction:
-        '服务器返回的价格无法显示。请尝试其他输入或模型。',
-      error_form_restore_failed: '已保存的表单数据无效，已重置。',
-      floor_area_unit: '平方米 (m²)',
       floor_area_unit_short: 'm²',
-      prediction_success: '预测完成！向下滚动查看结果。',
       models_count: '模型',
       towns_count: '城镇',
       flat_types_count: '房型'

--- a/src/app/services/i18n.resources.ts
+++ b/src/app/services/i18n.resources.ts
@@ -19,7 +19,9 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       switch_language: '中文/English',
       switch_to_dark: 'Dark Mode',
       switch_to_light: 'Light Mode',
-      price_prediction: 'Price Prediction',
+      switch_to_light_mode: 'Switch to light mode',
+      switch_to_dark_mode: 'Switch to dark mode',
+      price_prediction: 'Price\nPrediction',
       intro_eyebrow: 'Singapore HDB resale estimator',
       intro_blurb:
         'Compare flat attributes, submit a scenario, and get a quick resale estimate with a 12-month trend view.',
@@ -49,7 +51,21 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       awaiting_prediction: 'Awaiting prediction',
       results_placeholder_title: 'Run a scenario to generate a forecast',
       results_placeholder_body:
-        'Choose a model, adjust the flat details, and submit the form to see the projected resale price and 12-month trend.'
+        'Choose a model, adjust the flat details, and submit the form to see the projected resale price and 12-month trend.',
+      stat_models_hint:
+        'Machine learning models trained on HDB resale transactions.',
+      stat_towns_hint: 'Singapore towns covered in the resale dataset.',
+      stat_types_hint: 'HDB flat model types used as prediction inputs.',
+      error_invalid_prediction:
+        'The server returned prices we could not display. Try different inputs or a model.',
+      error_form_restore_failed:
+        'Saved form data was invalid and has been reset.',
+      floor_area_unit: 'Square metres (m²)',
+      prediction_success:
+        'Prediction complete! Scroll down to view results.',
+      models_count: 'Models',
+      towns_count: 'Towns',
+      flat_types_count: 'Flat Types'
     },
     options: {
       ml_models: {
@@ -134,7 +150,9 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       switch_language: '中文/English',
       switch_to_dark: '深色模式',
       switch_to_light: '浅色模式',
-      price_prediction: '价格预测',
+      switch_to_light_mode: '切换到浅色模式',
+      switch_to_dark_mode: '切换到深色模式',
+      price_prediction: '价格\n预测',
       intro_eyebrow: '新加坡组屋转售价估算器',
       intro_blurb:
         '比较房屋属性，提交一个情境，并快速查看估算转售价与过去12个月趋势。',
@@ -163,7 +181,18 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
       awaiting_prediction: '等待预测结果',
       results_placeholder_title: '提交一个情境后即可生成预测',
       results_placeholder_body:
-        '选择模型并调整房屋资料后提交表单，即可查看预测转售价与过去12个月趋势。'
+        '选择模型并调整房屋资料后提交表单，即可查看预测转售价与过去12个月趋势。',
+      stat_models_hint: '基于组屋转售成交数据训练的机器学习模型。',
+      stat_towns_hint: '数据集中涵盖的新加坡城镇。',
+      stat_types_hint: '用作预测输入的组屋房型。',
+      error_invalid_prediction:
+        '服务器返回的价格无法显示。请尝试其他输入或模型。',
+      error_form_restore_failed: '已保存的表单数据无效，已重置。',
+      floor_area_unit: '平方米 (m²)',
+      prediction_success: '预测完成！向下滚动查看结果。',
+      models_count: '模型',
+      towns_count: '城镇',
+      flat_types_count: '房型'
     },
     options: {
       ml_models: {

--- a/src/app/services/i18n.resources.ts
+++ b/src/app/services/i18n.resources.ts
@@ -16,9 +16,6 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
     labels: {
       loading_chart: 'Loading chart...',
       error_fetch: 'Failed to fetch prediction. Please try again.',
-      switch_language: '中文/English',
-      switch_to_dark: 'Dark Mode',
-      switch_to_light: 'Light Mode',
       switch_to_light_mode: 'Switch to light mode',
       switch_to_dark_mode: 'Switch to dark mode',
       language_label_en: 'English',
@@ -149,9 +146,6 @@ export const TRANSLATION_RESOURCES: Record<Lang, TranslationResource> = {
     labels: {
       loading_chart: '加载图表中...',
       error_fetch: '获取预测失败，请重试。',
-      switch_language: '中文/English',
-      switch_to_dark: '深色模式',
-      switch_to_light: '浅色模式',
       switch_to_light_mode: '切换到浅色模式',
       switch_to_dark_mode: '切换到深色模式',
       language_label_en: 'English',

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,31 +1,79 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Lora:ital,wght@0,400..700;1,400..700&display=swap');
+
+/* ── Design Tokens ────────────────────────────────────────────────
+   Indigo primary on taupe-neutral surfaces. Colors use light-dark()
+   so dark mode is automatic — no separate .dark block needed for
+   most values. body[data-theme] mirrors the shadcn .dark convention. */
+
 :root {
   color-scheme: light;
-  --font-body:
-    'DM Sans',
-    'Avenir Next',
-    'SF Pro Text',
-    'Helvetica Neue',
-    'Segoe UI',
-    Arial,
+
+  --font-body: 'DM Sans', 'Avenir Next', 'SF Pro Text', 'Helvetica Neue',
+    'Segoe UI', Arial, sans-serif;
+  --font-display: 'Lora', 'Iowan Old Style', 'Palatino Linotype',
+    'Book Antiqua', Georgia, serif;
+  --font-body-cjk: 'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC',
+    'Noto Sans SC', 'Microsoft YaHei', 'Source Han Sans SC', 'Heiti SC',
     sans-serif;
-  --font-body-cjk:
-    'PingFang SC',
-    'Hiragino Sans GB',
-    'Noto Sans CJK SC',
-    'Noto Sans SC',
-    'Microsoft YaHei',
-    'Source Han Sans SC',
-    'Heiti SC',
-    sans-serif;
-  --font-display:
-    'Lora',
-    'Iowan Old Style',
-    'Palatino Linotype',
-    'Book Antiqua',
-    Georgia,
-    serif;
+
+  --background: light-dark(#f2f3f8, #0c0f1d);
+  --foreground: light-dark(#0f172a, #f1f5f9);
+  --card: light-dark(#ffffff, #161929);
+  --card-foreground: light-dark(#0f172a, #f1f5f9);
+  --popover: light-dark(#ffffff, #161929);
+  --popover-foreground: light-dark(#0f172a, #f1f5f9);
+  --primary: light-dark(#4f46e5, #818cf8);
+  --primary-foreground: light-dark(#ffffff, #0f172a);
+  --secondary: light-dark(#f4f5fa, #111427);
+  --secondary-foreground: light-dark(#475569, #94a3b8);
+  --muted: light-dark(#f4f5fa, #111427);
+  --muted-foreground: light-dark(#64748b, #94a3b8);
+  --accent: light-dark(#eef2ff, rgba(129, 140, 248, 0.12));
+  --accent-foreground: light-dark(#4338ca, #e0e7ff);
+  --destructive: light-dark(#dc2626, #f87171);
+  --destructive-foreground: light-dark(#ffffff, #2a0c0c);
+  --border: light-dark(#e2e8f0, #272b42);
+  --input: light-dark(#e2e8f0, #353a55);
+  --ring: var(--primary);
+  --chart-1: var(--primary);
+  --chart-2: light-dark(#6366f1, #a5b4fc);
+  --chart-3: light-dark(#8b5cf6, #c4b5fd);
+  --chart-4: light-dark(#10b981, #4ade80);
+  --chart-5: light-dark(#f59e0b, #fbbf24);
+  --radius: 0.625rem;
+
+  /* Legacy aliases kept for chart + internal references */
+  --color-page: var(--background);
+  --color-surface: var(--card);
+  --color-input-bg: var(--secondary);
+  --color-text: var(--foreground);
+  --color-text-secondary: var(--secondary-foreground);
+  --color-text-muted: var(--muted-foreground);
+  --color-chart: var(--chart-1);
+  --color-on-primary: var(--primary-foreground);
+
+  /* Chart-specific tokens */
+  --chart-line: var(--primary);
+  --chart-fill: light-dark(
+    rgba(79, 70, 229, 0.10),
+    rgba(129, 140, 248, 0.12)
+  );
 }
 
+body[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+/* ── Language overrides ────────────────────────────────────────── */
+html[lang='zh'] {
+  --font-display: var(--font-body-cjk);
+}
+
+html[lang='zh'] body {
+  font-family: var(--font-body-cjk);
+}
+
+/* ── Base ───────────────────────────────────────────────────────── */
 * {
   box-sizing: border-box;
 }
@@ -38,24 +86,29 @@ body {
 }
 
 body {
-  background: #f5eee5;
-  color: #1f2328;
+  background: var(--background);
+  color: var(--foreground);
   font-family: var(--font-body);
-  transition:
-    background 0.35s ease,
-    color 0.25s ease;
-}
-
-body[data-theme='dark'] {
-  color-scheme: dark;
-}
-
-html[lang='zh'] {
-  --font-display: var(--font-body-cjk);
-}
-
-html[lang='zh'] body {
-  font-family: var(--font-body-cjk);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-image:
+    radial-gradient(
+      ellipse 80% 50% at 50% -20%,
+      color-mix(in oklab, var(--primary) 12%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      circle,
+      color-mix(in oklab, var(--primary) 10%, transparent) 1px,
+      transparent 1px
+    );
+  background-size:
+    100% 480px,
+    22px 22px;
+  background-position:
+    center top,
+    center center;
+  background-repeat: no-repeat, repeat;
 }
 
 button,
@@ -63,4 +116,118 @@ input,
 select,
 textarea {
   font: inherit;
+}
+
+/* ── Theme transitions (applied after mount) ───────────────────── */
+.theme-ready,
+.theme-ready *,
+.theme-ready *::before,
+.theme-ready *::after {
+  transition:
+    background-color 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
+}
+
+/* ── Animations ─────────────────────────────────────────────────── */
+@keyframes fade-up-deep {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes settle {
+  0% {
+    transform: scale(0.96);
+    opacity: 0.72;
+  }
+  65% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@keyframes pulse {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-2px);
+  }
+}
+
+@keyframes glow-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 12px
+      color-mix(in oklab, var(--primary) 20%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 28px
+      color-mix(in oklab, var(--primary) 35%, transparent);
+  }
+}
+
+@keyframes empty-float {
+  0%,
+  100% {
+    transform: translateY(0px) rotate(0deg);
+  }
+  25% {
+    transform: translateY(-3px) rotate(0.5deg);
+  }
+  75% {
+    transform: translateY(2px) rotate(-0.5deg);
+  }
+}
+
+@keyframes progress-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-deep,
+  .animate-settle,
+  .animate-stagger > *,
+  .animate-glow {
+    animation: none !important;
+  }
 }


### PR DESCRIPTION
## Summary
Port the shadcn/ui visual design system from the Next.js [prediction-tool PR #120](https://github.com/shenghaoc/prediction-tool/pull/120) to Angular:

- **Design tokens** — indigo-primary CSS-variable theme with shadcn naming conventions (`--primary`, `--background`, `--foreground`, `--card`, `--border`, etc.) and `light-dark()` dark mode
- **Page background** — dot-grid + top-glow gradients using `color-mix(in oklab, var(--primary) ...)`
- **7 new @keyframes** — fade-up-deep, shimmer, glow-pulse, empty-float, progress-indeterminate, etc.
- **Sticky header** — backdrop-blur, brand badge pill, outline icon buttons (sun/moon SVG)
- **Panel cards** — `ring-1 ring-foreground/5 shadow-sm`, `border-border/60`, `rounded-2xl`, `border-l-4 border-l-primary/70` accent
- **Stat tiles** — inline SVG icons (layers, map pin, home) + label + value, hover lift
- **Form fields** — `rounded-xl` inputs/selects with hover border, focus ring with shadow
- **Price badge** — gradient background with `glow-pulse` animation when prediction is active
- **Metric cards** — icon containers + label + value, hover border highlight
- **Chart area** — bordered gradient frame wrap, summary stat chips with trend arrows
- **Empty state** — animated floating bar chart + dashed border
- **Loading** — skeleton shimmer layout (shown pre-hydration), indeterminate progress bar
- **I18n** — 9 new keys in EN + ZH (stat hints, error messages, theme labels, prediction success)
- **Auto-scroll** — smooth scroll to results on prediction completion
- **Chart colors** — updated to indigo palette

## Test plan
- [x] `npm test` passes (4/4)
- [x] `npm run build` succeeds
- [ ] Open `/` in light and dark mode — cards, form, and results use shadcn styling consistently
- [ ] Exercise all five selects (keyboard + mouse)
- [ ] Submit a prediction — chart, price badge, and summary cards update with indigo colors
- [ ] Toggle 中文/English — headline respects `\n` line break
- [ ] Confirm dot-grid background is visible behind main content in both themes
- [ ] Verify skeleton loading screen shows briefly before content renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)