### PR TITLE
chore: add Dependabot groups for better update batching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,42 +11,24 @@ updates:
       angular:
         patterns:
           - '@angular/*'
-        update-types:
-          - 'minor'
-          - 'patch'
       typescript:
         patterns:
           - 'typescript'
           - 'tslib'
           - '@types/*'
-        update-types:
-          - 'minor'
-          - 'patch'
       testing:
         patterns:
           - 'jasmine-core'
           - 'karma'
           - 'karma-*'
-        update-types:
-          - 'minor'
-          - 'patch'
       charting:
         patterns:
           - 'chart.js'
           - 'ng2-charts'
-        update-types:
-          - 'minor'
-          - 'patch'
       cloudflare:
         patterns:
           - '@cloudflare/*'
           - 'wrangler'
-        update-types:
-          - 'minor'
-          - 'patch'
       miscellaneous:
         patterns:
           - '*'
-        update-types:
-          - 'minor'
-          - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,46 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "monthly"
+    groups:
+      angular:
+        patterns:
+          - '@angular/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      typescript:
+        patterns:
+          - 'typescript'
+          - 'tslib'
+          - '@types/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      testing:
+        patterns:
+          - 'jasmine-core'
+          - 'karma'
+          - 'karma-*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      charting:
+        patterns:
+          - 'chart.js'
+          - 'ng2-charts'
+        update-types:
+          - 'minor'
+          - 'patch'
+      cloudflare:
+        patterns:
+          - '@cloudflare/*'
+          - 'wrangler'
+        update-types:
+          - 'minor'
+          - 'patch'
+      miscellaneous:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates monthly
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
## Summary
- Added Dependabot dependency groups so related packages are updated together in single PRs
- **angular**: `@angular/*` — all framework packages
- **typescript**: `typescript`, `tslib`, `@types/*`
- **testing**: `jasmine-core`, `karma`, `karma-*`
- **charting**: `chart.js`, `ng2-charts`
- **cloudflare**: `@cloudflare/*`, `wrangler`
- **miscellaneous**: catch-all for remaining packages (`express`, `rxjs`, etc.)

## Test plan
- [ ] Verify Dependabot picks up the new config on next scheduled run
- [ ] Confirm grouped PRs batch related updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)