### PR TITLE
refactor: replace string-based date parsing with Temporal

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -36,7 +36,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
+                  "maximumWarning": "700kb",
                   "maximumError": "1mb"
                 },
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-server": "^21.0.2",
         "@angular/router": "^21.0.2",
         "@angular/ssr": "^21.0.1",
+        "@js-temporal/polyfill": "^0.5.1",
         "chart.js": "^4.5.1",
         "express": "^5.2.0",
         "ng2-charts": "^5.0.4",
@@ -3133,6 +3134,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@kurkle/color": {
@@ -7770,6 +7783,12 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-server": "^21.0.2",
     "@angular/router": "^21.0.2",
     "@angular/ssr": "^21.0.1",
+    "@js-temporal/polyfill": "^0.5.1",
     "chart.js": "^4.5.1",
     "express": "^5.2.0",
     "ng2-charts": "^5.0.4",

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -18,6 +18,7 @@ import {
   NgChartsModule
 } from 'ng2-charts';
 import type { ChartConfiguration } from 'chart.js';
+import { Temporal } from '@js-temporal/polyfill';
 
 import {
   flat_model_list,
@@ -75,7 +76,7 @@ type PredictionRequestPayload = {
 };
 
 const MIN_YEAR = 1960;
-const MAX_YEAR = parseInt(month_list[month_list.length - 1].substring(0, 4), 10);
+const MAX_YEAR = Temporal.PlainYearMonth.from(month_list[month_list.length - 1]).year;
 const MIN_FLOOR_AREA = 20;
 const MAX_FLOOR_AREA = 300;
 const PREDICTION_API_URL =


### PR DESCRIPTION
## Summary
- Add `@js-temporal/polyfill` for WebKit/Safari support (mirrors [prediction-tool@7e38d33](https://github.com/shenghaoc/prediction-tool/commit/7e38d3332bec0abc00e9ff8f5c769cc1159677d5))
- Replace `parseInt(monthStr.substring(0, 4), 10)` with `Temporal.PlainYearMonth.from(monthStr).year` for extracting the year from `'YYYY-MM'` strings
- Bump initial bundle budget from 500 kB to 700 kB to accommodate the polyfill
- i18n is already a lightweight custom `TranslationService` (~43 lines) — no heavy library to replace

## Test plan
- [ ] Verify build succeeds without warnings
- [ ] Confirm the prediction form works correctly (year extraction unchanged)
- [ ] Test on Safari/WebKit to verify polyfill works

🤖 Generated with [Claude Code](https://claude.com/claude-code)