### PR TITLE
refactor: modernise to Angular v21 idioms

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
@@ -7,7 +8,7 @@ describe('AppComponent', () => {
     localStorage.clear();
     await TestBed.configureTestingModule({
       imports: [AppComponent],
-      providers: [provideZonelessChangeDetection()]
+      providers: [provideZonelessChangeDetection(), provideHttpClient()]
     }).compileComponents();
   });
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -16,7 +16,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
     provideClientHydration(),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch()), // v22: withFetch() is deprecated; Fetch becomes the default — drop this argument when upgrading
     provideCharts({
       registerables: [
         LineController,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideCharts } from 'ng2-charts';
 import {
@@ -15,6 +16,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
     provideClientHydration(),
+    provideHttpClient(withFetch()),
     provideCharts({
       registerables: [
         LineController,

--- a/src/app/prediction-tool/combobox/combobox.component.ts
+++ b/src/app/prediction-tool/combobox/combobox.component.ts
@@ -3,11 +3,12 @@ import {
   Component,
   ElementRef,
   OnDestroy,
-  ViewChild,
   computed,
   forwardRef,
+  inject,
   input,
-  signal
+  signal,
+  viewChild
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -18,7 +19,6 @@ export interface ComboboxOption {
 
 @Component({
   selector: 'app-combobox',
-  standalone: true,
   templateUrl: './combobox.component.html',
   styleUrl: './combobox.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -43,8 +43,8 @@ export class ComboboxComponent implements ControlValueAccessor, OnDestroy {
   readonly ariaDescribedby = input<string | null>(null);
   readonly toggleLabel = input('Toggle options');
 
-  @ViewChild('inputEl') inputEl?: ElementRef<HTMLInputElement>;
-  @ViewChild('listboxEl') listboxEl?: ElementRef<HTMLUListElement>;
+  protected readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputEl');
+  protected readonly listboxEl = viewChild<ElementRef<HTMLUListElement>>('listboxEl');
 
   protected readonly value = signal<string>('');
   protected readonly query = signal<string>('');
@@ -97,6 +97,8 @@ export class ComboboxComponent implements ControlValueAccessor, OnDestroy {
     return `opt-${this.resolvedInputId()}-${idx}`;
   });
 
+  private readonly _elementRef = inject(ElementRef);
+
   private onChange: (value: string) => void = () => {};
   private onTouched: () => void = () => {};
   // Timeout ID for the post-open scroll; tracked so it can be cancelled on destroy.
@@ -123,8 +125,6 @@ export class ComboboxComponent implements ControlValueAccessor, OnDestroy {
       this.close();
     }
   }
-
-  constructor(private _elementRef: ElementRef) {}
 
   ngOnDestroy(): void {
     if (this.scrollTimeoutId !== null) {
@@ -267,7 +267,7 @@ export class ComboboxComponent implements ControlValueAccessor, OnDestroy {
           this.close();
           this.escapeDismissed = true;
           // Return focus to the input so the user can continue editing.
-          this.inputEl?.nativeElement.focus();
+          this.inputEl()?.nativeElement.focus();
         }
         break;
       case 'Tab':
@@ -286,7 +286,7 @@ export class ComboboxComponent implements ControlValueAccessor, OnDestroy {
       this.close();
     } else {
       this.open();
-      this.inputEl?.nativeElement.focus();
+      this.inputEl()?.nativeElement.focus();
     }
   }
 
@@ -321,7 +321,7 @@ export class ComboboxComponent implements ControlValueAccessor, OnDestroy {
       this.scrollActiveIntoView();
       // Select all text so the user can immediately type a new query without
       // having to manually clear the existing label.
-      this.inputEl?.nativeElement.select();
+      this.inputEl()?.nativeElement.select();
     }, 0);
   }
 
@@ -340,8 +340,9 @@ export class ComboboxComponent implements ControlValueAccessor, OnDestroy {
 
   private scrollActiveIntoView(): void {
     const idx = this.activeIndex();
-    if (idx < 0 || !this.listboxEl) return;
-    const listbox = this.listboxEl.nativeElement;
+    const listboxEl = this.listboxEl();
+    if (idx < 0 || !listboxEl) return;
+    const listbox = listboxEl.nativeElement;
     const item = listbox.children[idx] as HTMLElement | undefined;
     if (item) {
       item.scrollIntoView({ block: 'nearest' });

--- a/src/app/prediction-tool/number-field/number-field.component.ts
+++ b/src/app/prediction-tool/number-field/number-field.component.ts
@@ -3,17 +3,16 @@ import {
   Component,
   ElementRef,
   OnDestroy,
-  ViewChild,
   computed,
   forwardRef,
   input,
-  signal
+  signal,
+  viewChild
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
   selector: 'app-number-field',
-  standalone: true,
   templateUrl: './number-field.component.html',
   styleUrl: './number-field.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -37,7 +36,7 @@ export class NumberFieldComponent implements ControlValueAccessor, OnDestroy {
   readonly decreaseLabel = input('Decrease value');
   readonly increaseLabel = input('Increase value');
 
-  @ViewChild('inputEl') inputEl?: ElementRef<HTMLInputElement>;
+  protected readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputEl');
 
   protected readonly rawValue = signal<number | string>('');
   protected readonly focused = signal(false);
@@ -260,8 +259,9 @@ export class NumberFieldComponent implements ControlValueAccessor, OnDestroy {
     }
     // Explicitly sync the DOM value so invalid non-numeric text (e.g. "25a") is
     // cleared even when rawValue didn't change and Angular's binding won't re-fire.
-    if (this.inputEl) {
-      this.inputEl.nativeElement.value = this.displayValue();
+    const inputEl = this.inputEl();
+    if (inputEl) {
+      inputEl.nativeElement.value = this.displayValue();
     }
   }
 
@@ -272,11 +272,12 @@ export class NumberFieldComponent implements ControlValueAccessor, OnDestroy {
 
   /** If the DOM input shows invalid text, restore it to the last valid display value. */
   private restoreDisplayIfDirty(): void {
-    if (!this.inputEl) return;
-    const current = this.inputEl.nativeElement.value;
+    const inputEl = this.inputEl();
+    if (!inputEl) return;
+    const current = inputEl.nativeElement.value;
     const display = this.displayValue();
     if (current !== display) {
-      this.inputEl.nativeElement.value = display;
+      inputEl.nativeElement.value = display;
     }
   }
 }

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -101,8 +101,7 @@
               <h2 id="form-heading" class="section-title">{{ t('prediction_form') }}</h2>
 
               <form
-                [formGroup]="predictionForm"
-                (ngSubmit)="onSubmit()"
+                (submit)="onSubmit(); $event.preventDefault()"
                 novalidate
               >
                 <div class="form-grid">
@@ -110,7 +109,7 @@
                     <label class="field-label" for="field-ml-model">{{ t('ml_model') }}</label>
                     <app-combobox
                       inputId="field-ml-model"
-                      formControlName="mlModel"
+                      [field]="predictionForm.mlModel"
                       [options]="mlModelOptions()"
                       [placeholder]="t('ml_model')"
                       [ariaLabel]="t('ml_model')"
@@ -124,7 +123,7 @@
                     <label class="field-label" for="field-town">{{ t('town') }}</label>
                     <app-combobox
                       inputId="field-town"
-                      formControlName="town"
+                      [field]="predictionForm.town"
                       [options]="townOptions()"
                       [placeholder]="t('town')"
                       [ariaLabel]="t('town')"
@@ -138,7 +137,7 @@
                     <label class="field-label" for="field-storey-range">{{ t('storey_range') }}</label>
                     <app-combobox
                       inputId="field-storey-range"
-                      formControlName="storeyRange"
+                      [field]="predictionForm.storeyRange"
                       [options]="storeyRangeOptions()"
                       [placeholder]="t('storey_range')"
                       [ariaLabel]="t('storey_range')"
@@ -152,7 +151,7 @@
                     <label class="field-label" for="field-flat-model">{{ t('flat_model') }}</label>
                     <app-combobox
                       inputId="field-flat-model"
-                      formControlName="flatModel"
+                      [field]="predictionForm.flatModel"
                       [options]="flatModelOptions()"
                       [placeholder]="t('flat_model')"
                       [ariaLabel]="t('flat_model')"
@@ -166,7 +165,7 @@
                     <label class="field-label" for="field-floor-area">{{ t('floor_area') }}</label>
                     <app-number-field
                       inputId="field-floor-area"
-                      formControlName="floorAreaSqm"
+                      [field]="predictionForm.floorAreaSqm"
                       [min]="20"
                       [max]="300"
                       [step]="1"
@@ -177,16 +176,9 @@
                       [decreaseLabel]="t('decrease_value')"
                       [increaseLabel]="t('increase_value')"
                     ></app-number-field>
-                    @if (
-                      predictionForm.controls.floorAreaSqm.hasError('required') &&
-                      predictionForm.controls.floorAreaSqm.touched
-                    ) {
+                    @if (floorAreaRequiredError()) {
                       <span id="floor-area-error" class="field-error">{{ t('missing_floor_area') }}</span>
-                    } @else if (
-                      (predictionForm.controls.floorAreaSqm.hasError('min') ||
-                        predictionForm.controls.floorAreaSqm.hasError('max')) &&
-                      predictionForm.controls.floorAreaSqm.touched
-                    ) {
+                    } @else if (floorAreaRangeError()) {
                       <span id="floor-area-error" class="field-error">{{ t('floor_area_range') }}</span>
                     }
                   </div>
@@ -195,7 +187,7 @@
                     <label class="field-label" for="field-lease-year">{{ t('lease_commence_date') }}</label>
                     <app-combobox
                       inputId="field-lease-year"
-                      formControlName="leaseCommenceYear"
+                      [field]="predictionForm.leaseCommenceYear"
                       [options]="leaseYearOptions()"
                       [placeholder]="t('lease_commence_date')"
                       [ariaLabel]="t('lease_commence_date')"
@@ -204,11 +196,7 @@
                       [toggleLabel]="t('toggle_options')"
                       [required]="true"
                     ></app-combobox>
-                    @if (
-                      (predictionForm.controls.leaseCommenceYear.hasError('min') ||
-                        predictionForm.controls.leaseCommenceYear.hasError('max')) &&
-                      predictionForm.controls.leaseCommenceYear.touched
-                    ) {
+                    @if (leaseYearRangeError()) {
                       <span id="lease-year-error" class="field-error">{{ leaseYearRangeMessage() }}</span>
                     }
                   </div>
@@ -217,7 +205,7 @@
                     <button
                       class="btn-primary"
                       type="submit"
-                      [disabled]="predictionForm.invalid || loading()"
+                      [disabled]="predictionForm().invalid() || loading()"
                     >
                       <span [class.loading-pulse]="loading()">
                         {{ loading() ? t('predicting') : t('get_prediction') }}

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -101,7 +101,7 @@
               <h2 id="form-heading" class="section-title">{{ t('prediction_form') }}</h2>
 
               <form
-                (submit)="$event.preventDefault(); void onSubmit()"
+                (submit)="$event.preventDefault(); onSubmit()"
                 novalidate
               >
                 <div class="form-grid">

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -101,7 +101,7 @@
               <h2 id="form-heading" class="section-title">{{ t('prediction_form') }}</h2>
 
               <form
-                (submit)="onSubmit(); $event.preventDefault()"
+                (submit)="$event.preventDefault(); void onSubmit()"
                 novalidate
               >
                 <div class="form-grid">

--- a/src/app/prediction-tool/prediction-tool.component.spec.ts
+++ b/src/app/prediction-tool/prediction-tool.component.spec.ts
@@ -34,4 +34,18 @@ describe('PredictionToolComponent', () => {
     expect(compiled.querySelector('.price-value.awaiting')?.textContent)
       .toContain('Awaiting prediction');
   });
+
+  it('should reset form interaction state via predictionForm().reset()', async () => {
+    await fixture.whenStable();
+    const form = component['predictionForm'];
+
+    form().markAsTouched();
+    expect(form().touched()).toBeTrue();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    compiled.querySelector<HTMLButtonElement>('.btn-reset')?.click();
+    await fixture.whenStable();
+
+    expect(form().touched()).toBeFalse();
+  });
 });

--- a/src/app/prediction-tool/prediction-tool.component.spec.ts
+++ b/src/app/prediction-tool/prediction-tool.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PredictionToolComponent } from './prediction-tool.component';
@@ -11,7 +12,7 @@ describe('PredictionToolComponent', () => {
     localStorage.clear();
     await TestBed.configureTestingModule({
       imports: [PredictionToolComponent],
-      providers: [provideZonelessChangeDetection()]
+      providers: [provideZonelessChangeDetection(), provideHttpClient()]
     })
     .compileComponents();
 

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -1,22 +1,22 @@
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   ElementRef,
-  HostListener,
   OnInit,
   PLATFORM_ID,
-  ViewChild,
   computed,
+  effect,
   inject,
-  signal
+  signal,
+  viewChild
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { BaseChartDirective } from 'ng2-charts';
 import type { ChartConfiguration } from 'chart.js';
 import { Temporal } from '@js-temporal/polyfill';
+import { firstValueFrom } from 'rxjs';
+import { Field, form, max, min, required, submit, validate } from '@angular/forms/signals';
 
 import {
   flat_model_list,
@@ -44,8 +44,7 @@ type PredictionFormValue = {
   storeyRange: StoreyRange;
   flatModel: FlatModel;
   floorAreaSqm: number;
-  // string because the combobox CVA always emits strings; Angular's min/max
-  // validators coerce via parseFloat so validation still works correctly.
+  // string because the combobox CVA always emits strings.
   leaseCommenceYear: string;
 };
 
@@ -102,8 +101,11 @@ const INITIAL_FORM_VALUE: PredictionFormValue = {
   templateUrl: './prediction-tool.component.html',
   styleUrl: './prediction-tool.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(document:keydown)': 'onDocumentKeyDown($event)'
+  },
   imports: [
-    ReactiveFormsModule,
+    Field,
     BaseChartDirective,
     ComboboxComponent,
     NumberFieldComponent
@@ -112,14 +114,13 @@ const INITIAL_FORM_VALUE: PredictionFormValue = {
 export class PredictionToolComponent implements OnInit {
   protected readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly document = inject(DOCUMENT);
-  private readonly destroyRef = inject(DestroyRef);
   private readonly storageService = inject(StorageService);
-  private readonly formBuilder = inject(FormBuilder);
+  private readonly http = inject(HttpClient);
   private readonly translationService = inject(TranslationService);
 
-  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
-  @ViewChild('resultsAnchor') resultsAnchor?: ElementRef<HTMLElement>;
-  @ViewChild('resultsHeading') resultsHeadingEl?: ElementRef<HTMLElement>;
+  protected readonly chart = viewChild(BaseChartDirective);
+  protected readonly resultsAnchor = viewChild<ElementRef<HTMLElement>>('resultsAnchor');
+  protected readonly resultsHeadingEl = viewChild<ElementRef<HTMLElement>>('resultsHeading');
 
   protected readonly lang = this.translationService.lang;
   protected readonly mlModels = ml_model_list;
@@ -140,46 +141,35 @@ export class PredictionToolComponent implements OnInit {
   protected readonly trendData = signal<TrendPoint[]>(
     createDefaultTrendData()
   );
-  protected readonly summaryValues = signal<SummaryValues>({
-    mlModel: INITIAL_FORM_VALUE.mlModel,
-    town: INITIAL_FORM_VALUE.town,
-    leaseCommenceYear: Number(INITIAL_FORM_VALUE.leaseCommenceYear)
-  });
 
-  protected readonly mlModelOptions = computed(() => {
-    void this.lang();
-    return this.mlModels.map((m) => ({
+  protected readonly mlModelOptions = computed(() =>
+    this.mlModels.map((m) => ({
       value: m,
       label: this.translationService.translateOption('ml_models', m)
-    }));
-  });
+    }))
+  );
 
-  protected readonly townOptions = computed(() => {
-    // Depend on lang signal so options re-translate on language switch
-    void this.lang();
-    return this.towns.map((town) => ({
+  protected readonly townOptions = computed(() =>
+    this.towns.map((town) => ({
       value: town,
       label: this.translationService.translateOption('towns', town)
-    }));
-  });
+    }))
+  );
 
-  protected readonly storeyRangeOptions = computed(() => {
-    void this.lang();
-    return this.storeyRanges.map((s) => ({
+  protected readonly storeyRangeOptions = computed(() =>
+    this.storeyRanges.map((s) => ({
       value: s,
       label: this.translationService.translateOption('storey_ranges', s)
-    }));
-  });
+    }))
+  );
 
-  protected readonly flatModelOptions = computed(() => {
-    void this.lang();
-    return this.flatModels.map((f) => ({
+  protected readonly flatModelOptions = computed(() =>
+    this.flatModels.map((f) => ({
       value: f,
       label: this.translationService.translateOption('flat_models', f)
-    }));
-  });
+    }))
+  );
 
-  // leaseYears are plain numbers; no translation needed.
   protected readonly leaseYearOptions = computed(() =>
     this.leaseYears.map((y) => ({ value: String(y), label: String(y) }))
   );
@@ -257,9 +247,7 @@ export class PredictionToolComponent implements OnInit {
       id: 'latestGlow',
       afterDatasetsDraw: (chart: any) => {
         const { ctx } = chart;
-        // Guard: glow is '' until updateChartColorsCache() runs; an empty
-        // fillStyle produces an invisible fill, not a crash, but skip early
-        // to stay consistent with the gradientLine guard above.
+        // Guard: glow is '' until updateChartColorsCache() runs.
         if (!this.chartColors.glow) return;
         const meta = chart.getDatasetMeta(0);
         if (!meta || !meta.data || meta.data.length === 0) return;
@@ -335,8 +323,6 @@ export class PredictionToolComponent implements OnInit {
         y: {
           // grace adds padding above/below the data range so the line is
           // never squashed against the top or bottom of the chart area.
-          // Without this Chart.js defaults to starting at 0, which pushes
-          // HDB resale prices ($300k–$700k) into a thin band at the top.
           grace: '15%',
           grid: {
             color: (context: any) =>
@@ -355,30 +341,70 @@ export class PredictionToolComponent implements OnInit {
     };
   });
 
-  protected readonly predictionForm = this.formBuilder.nonNullable.group({
-    mlModel: [INITIAL_FORM_VALUE.mlModel, Validators.required],
-    town: [INITIAL_FORM_VALUE.town, Validators.required],
-    storeyRange: [INITIAL_FORM_VALUE.storeyRange, Validators.required],
-    flatModel: [INITIAL_FORM_VALUE.flatModel, Validators.required],
-    floorAreaSqm: [
-      INITIAL_FORM_VALUE.floorAreaSqm,
-      [
-        Validators.required,
-        Validators.min(MIN_FLOOR_AREA),
-        Validators.max(MAX_FLOOR_AREA)
-      ]
-    ],
-    leaseCommenceYear: [
-      INITIAL_FORM_VALUE.leaseCommenceYear,
-      [
-        Validators.min(MIN_YEAR),
-        Validators.max(MAX_YEAR)
-      ]
-    ]
+  private readonly predictionModel = signal<PredictionFormValue>({ ...INITIAL_FORM_VALUE });
+
+  protected readonly predictionForm = form(this.predictionModel, (s) => {
+    required(s.mlModel);
+    required(s.town);
+    required(s.storeyRange);
+    required(s.flatModel);
+    required(s.floorAreaSqm);
+    min(s.floorAreaSqm, MIN_FLOOR_AREA);
+    max(s.floorAreaSqm, MAX_FLOOR_AREA);
+    validate(s.leaseCommenceYear, ({ value }) => {
+      const n = Number(value());
+      if (!Number.isFinite(n) || n < MIN_YEAR || n > MAX_YEAR) {
+        return { kind: 'range' };
+      }
+      return undefined;
+    });
   });
 
-  @HostListener('document:keydown', ['$event'])
-  onDocumentKeyDown(event: KeyboardEvent): void {
+  protected readonly summaryValues = computed<SummaryValues>(() => {
+    const value = this.predictionModel();
+    return {
+      mlModel: coerceOption(value.mlModel, ml_model_list),
+      town: coerceOption(value.town, town_list),
+      leaseCommenceYear: clampNumber(value.leaseCommenceYear, MIN_YEAR, MAX_YEAR, MAX_YEAR)
+    };
+  });
+
+  protected readonly floorAreaErrorId = computed(() => {
+    const state = this.predictionForm.floorAreaSqm();
+    return state.touched() && state.errors().length > 0 ? 'floor-area-error' : null;
+  });
+
+  protected readonly floorAreaRequiredError = computed(() => {
+    const state = this.predictionForm.floorAreaSqm();
+    return state.touched() && state.errors().some(e => e.kind === 'required');
+  });
+
+  protected readonly floorAreaRangeError = computed(() => {
+    const state = this.predictionForm.floorAreaSqm();
+    return state.touched() && state.errors().some(e => e.kind === 'min' || e.kind === 'max');
+  });
+
+  protected readonly leaseYearErrorId = computed(() => {
+    const state = this.predictionForm.leaseCommenceYear();
+    return state.touched() && state.errors().length > 0 ? 'lease-year-error' : null;
+  });
+
+  protected readonly leaseYearRangeError = computed(() => {
+    const state = this.predictionForm.leaseCommenceYear();
+    return state.touched() && state.errors().some(e => e.kind === 'range');
+  });
+
+  constructor() {
+    // Persist form state to localStorage whenever the model changes.
+    // Writing to localStorage is a valid effect use case (imperative side effect).
+    effect(() => {
+      if (this.isBrowser) {
+        this.storageService.setItem('predictionFormData', this.predictionModel());
+      }
+    });
+  }
+
+  protected onDocumentKeyDown(event: KeyboardEvent): void {
     // Ignore events already handled by child components (e.g. Escape inside Combobox).
     if (event.defaultPrevented) {
       return;
@@ -405,102 +431,60 @@ export class PredictionToolComponent implements OnInit {
     if (this.isBrowser) {
       this.restoreTheme();
       this.restoreFormState();
+      this.syncDocumentState();
+      this.updateChartColorsCache();
     }
-
-    this.syncSummaryWithForm();
-    this.syncDocumentState();
-    this.updateChartColorsCache();
 
     this.mounted.set(true);
 
     if (this.isBrowser) {
       this.document.body.classList.add('theme-ready');
     }
-
-    this.predictionForm.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((partialValue) => {
-        const nextValue = {
-          ...this.predictionForm.getRawValue(),
-          ...partialValue
-        };
-
-        this.syncSummaryWithForm(nextValue);
-
-        if (!this.hasPrediction()) {
-          this.trendData.set(
-            createDefaultTrendData()
-          );
-        }
-
-        if (this.isBrowser) {
-          this.storageService.setItem('predictionFormData', nextValue);
-        }
-      });
   }
 
   protected async onSubmit(): Promise<void> {
-    if (this.predictionForm.invalid || !this.isBrowser || this.loading()) {
-      // Only mark touched when the form is invalid (not when blocking a concurrent request)
-      if (!this.loading()) this.predictionForm.markAllAsTouched();
-      return;
-    }
+    if (!this.isBrowser || this.loading()) return;
 
-    this.loading.set(true);
-    this.errorMessage.set('');
+    await submit(this.predictionForm, async () => {
+      this.loading.set(true);
+      this.errorMessage.set('');
 
-    const formValue = this.predictionForm.getRawValue();
-    const clampedFloorArea = clampNumber(
-      formValue.floorAreaSqm,
-      MIN_FLOOR_AREA,
-      MAX_FLOOR_AREA,
-      MIN_FLOOR_AREA
-    );
-    const predictionWindow = getPredictionWindow();
+      const formValue = this.predictionModel();
+      const clampedFloorArea = clampNumber(
+        formValue.floorAreaSqm,
+        MIN_FLOOR_AREA,
+        MAX_FLOOR_AREA,
+        MIN_FLOOR_AREA
+      );
 
-    if (clampedFloorArea !== formValue.floorAreaSqm) {
-      this.predictionForm.controls.floorAreaSqm.setValue(clampedFloorArea, {
-        emitEvent: false
-      });
-    }
-
-    const requestPayload: PredictionRequestPayload = {
-      model: formValue.mlModel,
-      monthStart: predictionWindow.monthStart,
-      monthEnd: predictionWindow.monthEnd,
-      town: formValue.town,
-      storeyRange: formValue.storeyRange,
-      flatModel: formValue.flatModel,
-      floorAreaSqm: clampedFloorArea.toString(),
-      leaseCommenceYear: formValue.leaseCommenceYear.toString()
-    };
-    const formData = createPredictionFormData(requestPayload);
-
-    try {
-      const response = await fetch(PREDICTION_API_URL, {
-        method: 'POST',
-        body: formData
-      });
-      const responseText = await response.text();
-
-      if (!response.ok) {
-        throw new Error(
-          formatPredictionError(
-            `API request failed with ${response.status} ${response.statusText}`,
-            responseText,
-            requestPayload
-          )
-        );
+      if (clampedFloorArea !== formValue.floorAreaSqm) {
+        this.predictionModel.update(v => ({ ...v, floorAreaSqm: clampedFloorArea }));
       }
 
-      const serverData = parsePredictionResponse(responseText, requestPayload);
-      const normalizedData = normalizeTrendData(serverData);
+      const predictionWindow = getPredictionWindow();
+      const requestPayload: PredictionRequestPayload = {
+        model: formValue.mlModel,
+        monthStart: predictionWindow.monthStart,
+        monthEnd: predictionWindow.monthEnd,
+        town: formValue.town,
+        storeyRange: formValue.storeyRange,
+        flatModel: formValue.flatModel,
+        floorAreaSqm: clampedFloorArea.toString(),
+        leaseCommenceYear: formValue.leaseCommenceYear.toString()
+      };
+      const formData = createPredictionFormData(requestPayload);
 
-      this.hasPrediction.set(true);
-      this.trendData.set(normalizedData);
-      this.chart?.update();
+      try {
+        const responseText = await firstValueFrom(
+          this.http.post(PREDICTION_API_URL, formData, { responseType: 'text' })
+        );
+        const serverData = parsePredictionResponse(responseText, requestPayload);
+        const normalizedData = normalizeTrendData(serverData);
 
-      if (this.isBrowser) {
+        this.hasPrediction.set(true);
+        this.trendData.set(normalizedData);
+        this.chart()?.update();
+
         const latestValue = normalizedData.at(-1)?.value ?? 0;
         const priceStr = formatCurrency(sanitizeCurrencyValue(latestValue));
         const announcement = this.t('prediction_complete').replace('{price}', priceStr);
@@ -509,10 +493,10 @@ export class PredictionToolComponent implements OnInit {
         this.liveMessage.set('');
         requestAnimationFrame(() => {
           this.liveMessage.set(announcement);
-          this.resultsAnchor?.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          this.resultsAnchor()?.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
           // Focus the results heading for keyboard users, then drop the
           // temporary tabindex once focus leaves so it isn't left interactive.
-          const heading = this.resultsHeadingEl?.nativeElement;
+          const heading = this.resultsHeadingEl()?.nativeElement;
           if (heading) {
             heading.setAttribute('tabindex', '-1');
             heading.focus({ preventScroll: true });
@@ -523,30 +507,31 @@ export class PredictionToolComponent implements OnInit {
             );
           }
         });
+      } catch (error: unknown) {
+        if (error instanceof HttpErrorResponse) {
+          console.error('Prediction request failed', {
+            summary: formatPredictionError(
+              `API request failed with ${error.status} ${error.statusText}`,
+              typeof error.error === 'string' ? error.error : '',
+              requestPayload
+            )
+          });
+        } else {
+          console.error('Prediction request failed', { error, requestPayload });
+        }
+        this.errorMessage.set(this.t('error_fetch'));
+      } finally {
+        this.loading.set(false);
       }
-    } catch (error: unknown) {
-      console.error('Prediction request failed', {
-        error,
-        requestPayload
-      });
-      this.errorMessage.set(this.t('error_fetch'));
-    } finally {
-      this.loading.set(false);
-    }
+    });
   }
 
   protected resetForm(): void {
-    this.predictionForm.reset(INITIAL_FORM_VALUE);
+    this.predictionModel.set({ ...INITIAL_FORM_VALUE });
+    this.predictionForm().reset();
     this.hasPrediction.set(false);
     this.errorMessage.set('');
-    this.trendData.set(
-      createDefaultTrendData()
-    );
-    this.syncSummaryWithForm(INITIAL_FORM_VALUE);
-
-    if (this.isBrowser) {
-      this.storageService.removeItem('predictionFormData');
-    }
+    this.trendData.set(createDefaultTrendData());
   }
 
   protected toggleTheme(): void {
@@ -562,7 +547,7 @@ export class PredictionToolComponent implements OnInit {
 
     this.syncDocumentState();
     this.updateChartColorsCache();
-    this.chart?.update();
+    this.chart()?.update();
   }
 
   protected toggleLanguage(): void {
@@ -576,28 +561,6 @@ export class PredictionToolComponent implements OnInit {
 
   protected tOption(group: OptionGroup, value: string): string {
     return this.translationService.translateOption(group, value);
-  }
-
-  // A plain method (not a computed signal) is correct here. statusChanges
-  // only emits on VALID/INVALID/PENDING transitions — it does NOT emit when
-  // markAllAsTouched() is called on an already-INVALID control (touched state
-  // changes but validation status stays INVALID). A plain method is always
-  // re-evaluated during the CD run that follows any zone-triggered event
-  // (including the form submit that calls markAllAsTouched()), so it reliably
-  // reflects the current touched+error state without missing the key case.
-  protected floorAreaErrorId(): string | null {
-    const c = this.predictionForm.controls.floorAreaSqm;
-    return c.touched &&
-      (c.hasError('required') || c.hasError('min') || c.hasError('max'))
-      ? 'floor-area-error'
-      : null;
-  }
-
-  protected leaseYearErrorId(): string | null {
-    const c = this.predictionForm.controls.leaseCommenceYear;
-    return c.touched && (c.hasError('min') || c.hasError('max'))
-      ? 'lease-year-error'
-      : null;
   }
 
   protected leaseYearRangeMessage(): string {
@@ -641,13 +604,10 @@ export class PredictionToolComponent implements OnInit {
       );
 
     if (!savedForm) {
-      this.trendData.set(
-        createDefaultTrendData()
-      );
       return;
     }
 
-    const restoredFormValue: PredictionFormValue = {
+    this.predictionModel.set({
       mlModel: coerceOption(savedForm.mlModel, ml_model_list),
       town: coerceOption(savedForm.town, town_list),
       storeyRange: coerceOption(savedForm.storeyRange, storey_range_list),
@@ -658,36 +618,12 @@ export class PredictionToolComponent implements OnInit {
         MAX_FLOOR_AREA,
         MIN_FLOOR_AREA
       ),
-      // Stored as string to match the combobox CVA; clampNumber coerces safely.
       leaseCommenceYear: String(clampNumber(
         savedForm.leaseCommenceYear,
         MIN_YEAR,
         MAX_YEAR,
         MAX_YEAR
       ))
-    };
-
-    this.predictionForm.setValue(restoredFormValue, {
-      emitEvent: false
-    });
-    this.trendData.set(
-      createDefaultTrendData()
-    );
-    this.syncSummaryWithForm(restoredFormValue);
-  }
-
-  private syncSummaryWithForm(
-    value: Partial<PredictionFormValue> = this.predictionForm.getRawValue()
-  ): void {
-    this.summaryValues.set({
-      mlModel: coerceOption(value.mlModel, ml_model_list),
-      town: coerceOption(value.town, town_list),
-      leaseCommenceYear: clampNumber(
-        value.leaseCommenceYear,
-        MIN_YEAR,
-        MAX_YEAR,
-        MAX_YEAR
-      )
     });
   }
 
@@ -696,7 +632,7 @@ export class PredictionToolComponent implements OnInit {
       return;
     }
 
-    const currentLanguage = this.translationService.currentLang();
+    const currentLanguage = this.translationService.lang();
     this.document.documentElement.lang = currentLanguage;
     this.document.documentElement.setAttribute(
       'data-lang',
@@ -823,9 +759,6 @@ function clampNumber(
   max: number,
   fallback: number
 ): number {
-  // Accept both plain numbers and string-encoded numbers (e.g. from combobox CVA
-  // which always emits strings, or from localStorage where JSON round-trips may
-  // preserve the original number type).
   const n = typeof value === 'number' ? value
           : typeof value === 'string' ? Number(value)
           : NaN;

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -528,6 +528,7 @@ export class PredictionToolComponent implements OnInit {
 
   protected resetForm(): void {
     this.predictionModel.set({ ...INITIAL_FORM_VALUE });
+    // Clear touched/dirty/error state; the model update above does not reset interaction flags.
     this.predictionForm().reset();
     this.hasPrediction.set(false);
     this.errorMessage.set('');
@@ -563,11 +564,11 @@ export class PredictionToolComponent implements OnInit {
     return this.translationService.translateOption(group, value);
   }
 
-  protected leaseYearRangeMessage(): string {
-    return this.t('lease_year_range')
+  protected readonly leaseYearRangeMessage = computed(() =>
+    this.t('lease_year_range')
       .replace('{min}', String(MIN_YEAR))
-      .replace('{max}', String(MAX_YEAR));
-  }
+      .replace('{max}', String(MAX_YEAR))
+  );
 
   protected formatCurrency(value: number): string {
     return formatCurrency(value);

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -528,7 +528,8 @@ export class PredictionToolComponent implements OnInit {
 
   protected resetForm(): void {
     this.predictionModel.set({ ...INITIAL_FORM_VALUE });
-    // Clear touched/dirty/error state; the model update above does not reset interaction flags.
+    // Signal Forms API: call the field tree for FieldState, then reset interaction
+    // flags on the form and all descendants (documented as form().reset()).
     this.predictionForm().reset();
     this.hasPrediction.set(false);
     this.errorMessage.set('');

--- a/src/app/services/translation.service.ts
+++ b/src/app/services/translation.service.ts
@@ -17,10 +17,6 @@ export class TranslationService {
     return TRANSLATION_RESOURCES[this.lang()].options[group][value] ?? value;
   }
 
-  currentLang(): Lang {
-    return this.lang();
-  }
-
   setLanguage(lang: Lang): void {
     this.lang.set(lang);
     this.storageService.setItem('lang', lang);


### PR DESCRIPTION
- Migrate form from ReactiveFormsModule/FormBuilder to Signal Forms
  (@angular/forms/signals): model signal, form(), submit(), required(),
  min(), max(), validate(); [field] directive binds combobox and
  number-field via the CVA compatibility layer
- Replace raw fetch() with HttpClient (provideHttpClient(withFetch())
  added to app.config); HttpErrorResponse used for typed error handling
- Replace all @ViewChild decorators with viewChild() signal queries
  across PredictionToolComponent, ComboboxComponent, NumberFieldComponent
- Move @HostListener to host object in @Component decorator
- Remove standalone: true from ComboboxComponent and NumberFieldComponent
  (default since Angular 19)
- Inject ElementRef via inject() instead of constructor parameter in
  ComboboxComponent; remove now-empty constructor
- Remove void this.lang() dependency-tracking hack in computed signals;
  translateOption/translate already read lang() internally, making the
  explicit calls redundant
- Remove currentLang() wrapper method from TranslationService; call
  lang() signal directly at usage sites
- summaryValues is now a computed() derived from the model signal;
  syncSummaryWithForm() and valueChanges subscription removed
- Form persistence moved to an effect() in the constructor (valid
  use case: syncing to localStorage, an imperative side effect)
- Error-kind checks (required/min/max/range) extracted to named
  computed signals to comply with Angular template expression rules

https://claude.ai/code/session_01D3Re8TfdfdnL9qhZbBGZxk