### PR TITLE
⚡ Bolt: Cache theme CSS variables to eliminate layout thrashing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - Avoid `getComputedStyle` in computed properties or render cycles
+**Learning:** Calling `getComputedStyle(document.body)` inside Angular signals or component rendering cycles (like `chartData` and `chartOptions`) triggers synchronous style recalculations. If these signals are re-evaluated frequently (e.g. when data updates), this can cause severe layout thrashing and performance bottlenecks.
+**Action:** When a component relies on CSS variables for styling elements (like Chart.js configs), extract the variables via `getComputedStyle` *exactly once* during initialization and on theme toggle. Store the resolved colors in a simple cache object, and read from the cache during regular change detection.

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -208,11 +208,11 @@ export class PredictionToolComponent implements OnInit {
         {
           data: this.trendData().map((point) => point.value),
           label: this.t('predicted_price'),
-          borderColor: readCssVar('--primary', this.document),
-          backgroundColor: readCssVar('--chart-fill', this.document),
-          pointBackgroundColor: readCssVar('--primary', this.document),
-          pointHoverBackgroundColor: readCssVar('--primary', this.document),
-          pointHoverBorderColor: readCssVar('--card', this.document),
+          borderColor: this.chartColors.primary,
+          backgroundColor: this.chartColors.chartFill,
+          pointBackgroundColor: this.chartColors.primary,
+          pointHoverBackgroundColor: this.chartColors.primary,
+          pointHoverBorderColor: this.chartColors.card,
           fill: true,
           tension: 0.35,
           borderWidth: 3
@@ -224,7 +224,20 @@ export class PredictionToolComponent implements OnInit {
   // Chart plugin color cache: updated once in ngOnInit and on every theme toggle.
   // The plugin array is stable (never recreated), so Chart.js doesn't re-register
   // plugins on each theme change.
-  private readonly chartColors = { c1: '', c2: '', glow: '' };
+  private readonly chartColors = {
+    c1: '',
+    c2: '',
+    glow: '',
+    primary: '',
+    chartFill: '',
+    card: '',
+    mutedForeground: '',
+    popover: '',
+    foreground: '',
+    tooltipBorder: '',
+    gridColor: '',
+    dashedGridColor: ''
+  };
 
   protected readonly chartPlugins = [
     {
@@ -269,13 +282,6 @@ export class PredictionToolComponent implements OnInit {
   >(() => {
     void this.darkMode();
     if (!this.isBrowser) return {};
-    const doc = this.document;
-    const labelColor = readCssVar('--muted-foreground', doc);
-    const panelColor = readCssVar('--popover', doc);
-    const foregroundColor = readCssVar('--foreground', doc);
-    const tooltipBorder = colorWithAlpha(readCssVar('--primary', doc), 0.16);
-    const gridColor = colorWithAlpha(foregroundColor, 0.08);
-    const dashedGridColor = colorWithAlpha(foregroundColor, 0.06);
 
     return {
       responsive: true,
@@ -289,10 +295,10 @@ export class PredictionToolComponent implements OnInit {
         },
         tooltip: {
           displayColors: false,
-          backgroundColor: panelColor,
-          titleColor: foregroundColor,
-          bodyColor: foregroundColor,
-          borderColor: tooltipBorder,
+          backgroundColor: this.chartColors.popover,
+          titleColor: this.chartColors.foreground,
+          bodyColor: this.chartColors.foreground,
+          borderColor: this.chartColors.tooltipBorder,
           borderWidth: 1,
           callbacks: {
             label: (context) => {
@@ -315,7 +321,7 @@ export class PredictionToolComponent implements OnInit {
             display: false
           },
           ticks: {
-            color: labelColor,
+            color: this.chartColors.mutedForeground,
             maxRotation: 0,
             autoSkip: true
           }
@@ -326,14 +332,14 @@ export class PredictionToolComponent implements OnInit {
           grace: '15%',
           grid: {
             color: (context: any) =>
-              context.index === 0 ? gridColor : dashedGridColor,
+              context.index === 0 ? this.chartColors.gridColor : this.chartColors.dashedGridColor,
             lineWidth: 1,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             borderDash: ((context: any) => context.index === 0 ? [] : [3, 4]) as any,
             drawBorder: false
           },
           ticks: {
-            color: labelColor,
+            color: this.chartColors.mutedForeground,
             callback: (value) => formatCompactCurrency(Number(value))
           }
         }
@@ -587,10 +593,30 @@ export class PredictionToolComponent implements OnInit {
 
   private updateChartColorsCache(): void {
     if (!this.isBrowser) return;
-    const doc = this.document;
-    this.chartColors.c1 = readCssVar('--chart-1', doc);
-    this.chartColors.c2 = readCssVar('--chart-2', doc);
-    this.chartColors.glow = colorWithAlpha(readCssVar('--primary', doc), 0.15);
+
+    // Get computed styles exactly once per theme change
+    const styles = getComputedStyle(this.document.body);
+
+    // Helper to read without repeating getComputedStyle
+    const read = (name: string) => styles.getPropertyValue(name).trim();
+
+    this.chartColors.c1 = read('--chart-1');
+    this.chartColors.c2 = read('--chart-2');
+
+    const primary = read('--primary');
+    this.chartColors.primary = primary;
+    this.chartColors.glow = colorWithAlpha(primary, 0.15);
+
+    this.chartColors.chartFill = read('--chart-fill');
+    this.chartColors.card = read('--card');
+    this.chartColors.mutedForeground = read('--muted-foreground');
+    this.chartColors.popover = read('--popover');
+
+    const foreground = read('--foreground');
+    this.chartColors.foreground = foreground;
+    this.chartColors.tooltipBorder = colorWithAlpha(primary, 0.16);
+    this.chartColors.gridColor = colorWithAlpha(foreground, 0.08);
+    this.chartColors.dashedGridColor = colorWithAlpha(foreground, 0.06);
   }
 
   private restoreTheme(): void {
@@ -789,10 +815,6 @@ function roundValue(value: number): number {
 
 function formatCurrency(value: number): string {
   return `$${sanitizeCurrencyValue(value).toLocaleString()}`;
-}
-
-function readCssVar(name: string, doc: Document): string {
-  return getComputedStyle(doc.body).getPropertyValue(name).trim();
 }
 
 function colorWithAlpha(color: string, alpha: number): string {


### PR DESCRIPTION
💡 **What:** Caches all theme-related CSS variable values into a single `chartColors` cache object during component initialization and theme toggling. Removes the `readCssVar` utility that was calling `getComputedStyle(document.body)` on every execution.

🎯 **Why:** Previously, `chartData` and `chartOptions` computed signals invoked `readCssVar` repeatedly to fetch chart colors. Because these signals re-evaluate on data changes (e.g. streaming trend predictions), the multiple `getComputedStyle` calls triggered synchronous style recalculations on every render update, causing severe layout thrashing and degrading main-thread performance.

📊 **Impact:** Reduces forced synchronous layouts from 5+ per data frame down to exactly 1 execution *only* when the theme changes. Should result in significantly smoother main thread execution and UI responsiveness during the prediction result sequence.

🔬 **Measurement:** Can be verified by using Chrome DevTools Performance panel to observe the elimination of "Recalculate Style" events during data streaming / chart redraws.

---
*PR created automatically by Jules for task [7980248326826465357](https://jules.google.com/task/7980248326826465357) started by @shenghaoc*