### PR TITLE
Refactor prediction flow to idiomatic Angular 21 (signals, Material, resource)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,6 +22,7 @@
               "src/assets"
             ],
             "styles": [
+              "src/material-theme.scss",
               "src/styles.css"
             ],
             "scripts": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "prediction-tool-ng",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/cdk": "^21.2.13",
         "@angular/common": "^21.2.15",
         "@angular/compiler": "^21.2.15",
         "@angular/core": "^21.2.15",
         "@angular/forms": "^21.2.15",
+        "@angular/material": "^21.2.13",
         "@angular/platform-browser": "^21.2.15",
         "@js-temporal/polyfill": "^0.5.1",
         "chart.js": "^4.5.1",
@@ -301,6 +303,40 @@
         }
       }
     },
+    "node_modules/@angular-devkit/architect/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/schematics": {
       "version": "21.2.13",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.13.tgz",
@@ -346,6 +382,40 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/build": {
@@ -449,11 +519,10 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.0.1.tgz",
-      "integrity": "sha512-9u1oUf6TGf9Wh+XuQFb9txIGAqfXbAX9ba+dyOTIJ7V3weX3kTRWeGjxad4ydjTPkJ3RaF1/upMwzLuZgnhDMQ==",
+      "version": "21.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.13.tgz",
+      "integrity": "sha512-nQGGJ6Efqi8n0qhT/PllsaIIY+vz+TL7/tpR7F2QKiqzS/9l4m7ea0vvS6fSMGrjEbqbkzTHbjLDsIg6X2hK+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -461,6 +530,7 @@
       "peerDependencies": {
         "@angular/common": "^21.0.0 || ^22.0.0",
         "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -525,6 +595,40 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cli/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/common": {
@@ -659,6 +763,23 @@
         "@angular/common": "21.2.15",
         "@angular/core": "21.2.15",
         "@angular/platform-browser": "21.2.15",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "21.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-21.2.13.tgz",
+      "integrity": "sha512-6gWFb9LNh4cRIvkdocktej6MUVuGa9HQvap+j9gbZOtiveD7ER+FByUPlLlypreRebF29G2MRZeshKSdmv4NbA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "21.2.13",
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/forms": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -1726,9 +1847,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1746,9 +1864,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1766,9 +1881,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1786,9 +1898,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1806,9 +1915,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1826,9 +1932,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1846,9 +1949,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1866,9 +1966,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1886,9 +1983,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1912,9 +2006,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1938,9 +2029,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1964,9 +2052,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1990,9 +2075,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2016,9 +2098,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2042,9 +2121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2068,9 +2144,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2991,9 +3064,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3011,9 +3081,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3031,9 +3098,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3051,9 +3115,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3071,9 +3132,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3091,9 +3149,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3111,9 +3166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3614,9 +3666,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3638,9 +3687,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3662,9 +3708,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3686,9 +3729,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3710,9 +3750,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3734,9 +3771,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3979,9 +4013,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3999,9 +4030,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4019,9 +4047,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4039,9 +4064,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4218,9 +4240,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4235,9 +4254,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4252,9 +4268,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4269,9 +4282,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4286,9 +4296,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4303,9 +4310,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4320,9 +4324,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4337,9 +4338,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4354,9 +4352,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4371,9 +4366,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4388,9 +4380,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4405,9 +4394,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4422,9 +4408,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4558,6 +4541,40 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sigstore/bundle": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/cdk": "^21.2.13",
     "@angular/common": "^21.2.15",
     "@angular/compiler": "^21.2.15",
     "@angular/core": "^21.2.15",
     "@angular/forms": "^21.2.15",
+    "@angular/material": "^21.2.13",
     "@angular/platform-browser": "^21.2.15",
     "@js-temporal/polyfill": "^0.5.1",
     "chart.js": "^4.5.1",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,30 +1,11 @@
 import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient, withFetch } from '@angular/common/http';
-import { provideCharts } from 'ng2-charts';
-import {
-  CategoryScale,
-  Filler,
-  LinearScale,
-  LineController,
-  LineElement,
-  PointElement,
-  Tooltip
-} from 'chart.js';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
     provideHttpClient(withFetch()), // v22: withFetch() is deprecated; Fetch becomes the default — drop this argument when upgrading
-    provideCharts({
-      registerables: [
-        LineController,
-        LinearScale,
-        CategoryScale,
-        PointElement,
-        LineElement,
-        Filler,
-        Tooltip,
-      ]
-    }),
+    // chart.js is registered at the component level in PredictionChartComponent so
+    // it stays out of the eager bundle and ships in the lazy @defer chunk instead.
   ]
 };

--- a/src/app/prediction-tool/prediction-chart.component.ts
+++ b/src/app/prediction-tool/prediction-chart.component.ts
@@ -1,0 +1,59 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { BaseChartDirective, provideCharts } from 'ng2-charts';
+import {
+  CategoryScale,
+  Filler,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  Tooltip
+} from 'chart.js';
+import type { ChartConfiguration, Plugin } from 'chart.js';
+
+/**
+ * Renders the prediction line chart.
+ *
+ * Kept as its own standalone component so the heavy `chart.js` dependency —
+ * registered here via the component-level `provideCharts` — is only pulled into
+ * a lazy chunk when the parent's `@defer` block loads this component. The parent
+ * deals only in chart.js *types* (erased at build time), so nothing chart.js
+ * touches the eager/main bundle.
+ */
+@Component({
+  selector: 'app-prediction-chart',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  // Block host so the frame fills the column width, matching the previous layout
+  // where `.chart-frame` was a direct block-level child of the chart shell.
+  styles: ':host { display: block; }',
+  imports: [BaseChartDirective],
+  providers: [
+    provideCharts({
+      registerables: [
+        LineController,
+        LinearScale,
+        CategoryScale,
+        PointElement,
+        LineElement,
+        Filler,
+        Tooltip
+      ]
+    })
+  ],
+  template: `
+    <div class="chart-frame">
+      <canvas
+        baseChart
+        [type]="'line'"
+        [data]="data()"
+        [options]="options()"
+        [plugins]="plugins()"
+      ></canvas>
+    </div>
+  `
+})
+export class PredictionChartComponent {
+  readonly data = input.required<ChartConfiguration<'line'>['data']>();
+  readonly options = input.required<ChartConfiguration<'line'>['options']>();
+  readonly plugins = input.required<Plugin<'line'>[]>();
+}

--- a/src/app/prediction-tool/prediction-form.validators.ts
+++ b/src/app/prediction-tool/prediction-form.validators.ts
@@ -1,4 +1,4 @@
-import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { AbstractControl, ValidationErrors } from '@angular/forms';
 
 export function integerValidator(control: AbstractControl): ValidationErrors | null {
   const value = control.value;
@@ -8,26 +8,4 @@ export function integerValidator(control: AbstractControl): ValidationErrors | n
 
   const numeric = Number(value);
   return Number.isInteger(numeric) ? null : { integer: true };
-}
-
-export function floorAreaValidators(
-  min: number,
-  max: number
-): ValidatorFn[] {
-  return [
-    (control) => (control.value === null || control.value === '' ? { required: true } : null),
-    (control) => {
-      const numeric = Number(control.value);
-      if (!Number.isFinite(numeric)) {
-        return { required: true };
-      }
-      if (numeric < min) {
-        return { min: { min, actual: numeric } };
-      }
-      if (numeric > max) {
-        return { max: { max, actual: numeric } };
-      }
-      return integerValidator(control);
-    }
-  ];
 }

--- a/src/app/prediction-tool/prediction-form.validators.ts
+++ b/src/app/prediction-tool/prediction-form.validators.ts
@@ -1,0 +1,33 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function integerValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value;
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const numeric = Number(value);
+  return Number.isInteger(numeric) ? null : { integer: true };
+}
+
+export function floorAreaValidators(
+  min: number,
+  max: number
+): ValidatorFn[] {
+  return [
+    (control) => (control.value === null || control.value === '' ? { required: true } : null),
+    (control) => {
+      const numeric = Number(control.value);
+      if (!Number.isFinite(numeric)) {
+        return { required: true };
+      }
+      if (numeric < min) {
+        return { min: { min, actual: numeric } };
+      }
+      if (numeric > max) {
+        return { max: { max, actual: numeric } };
+      }
+      return integerValidator(control);
+    }
+  ];
+}

--- a/src/app/prediction-tool/prediction-tool.component.css
+++ b/src/app/prediction-tool/prediction-tool.component.css
@@ -878,34 +878,8 @@
   height: 12px;
 }
 
-/* ── Chart Frame ────────────────────────────────────────────────── */
-.chart-frame {
-  min-height: 340px;
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  padding: 8px;
-  border-radius: var(--radius-sm, 3px);
-  border: 1px solid var(--border);
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklab, var(--secondary) 20%, transparent) 0%,
-    color-mix(in oklab, var(--secondary) 5%, transparent) 100%
-  );
-  transition:
-    background 200ms ease,
-    border-color 200ms ease;
-}
-
-.chart-frame-placeholder {
-  align-items: center;
-  justify-content: center;
-}
-
-.chart-frame canvas {
-  width: 100% !important;
-  height: 100% !important;
-}
+/* Chart frame styles live in global styles.css so the deferred
+   PredictionChartComponent and the placeholder divs share them. */
 
 /* ── Shortcut Hints ─────────────────────────────────────────────── */
 .shortcut-hint {

--- a/src/app/prediction-tool/prediction-tool.component.css
+++ b/src/app/prediction-tool/prediction-tool.component.css
@@ -1089,3 +1089,34 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Angular Material form fields ─────────────────────────────── */
+.material-form-grid mat-form-field {
+  width: 100%;
+}
+
+.material-form-grid .mat-mdc-form-field-subscript-wrapper {
+  margin-top: 2px;
+}
+
+.material-form-grid .mat-mdc-text-field-wrapper {
+  background: var(--card);
+}
+
+.material-form-grid .mdc-notched-outline__leading,
+.material-form-grid .mdc-notched-outline__notch,
+.material-form-grid .mdc-notched-outline__trailing {
+  border-color: var(--border);
+}
+
+.material-form-grid .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+.material-form-grid .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+.material-form-grid .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--primary);
+}
+
+.material-form-grid .mat-mdc-form-field-error {
+  color: var(--destructive);
+  font-size: 12px;
+  font-weight: 600;
+}

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -58,35 +58,31 @@
                 <p class="lead">{{ t('intro_blurb') }}</p>
 
                 <div class="figure-row">
-                  <div class="stat-tile">
-                    <div class="stat-tile-icon" aria-hidden="true">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2"/><line x1="12" y1="22" x2="12" y2="15.5"/><polyline points="22 8.5 12 15.5 2 8.5"/></svg>
+                  @for (stat of [
+                    { labelKey: 'models_count', value: mlModels.length, icon: 'model' },
+                    { labelKey: 'towns_count', value: towns.length, icon: 'town' },
+                    { labelKey: 'flat_types_count', value: flatModels.length, icon: 'flat' }
+                  ]; track stat.labelKey) {
+                    <div class="stat-tile">
+                      <div class="stat-tile-icon" aria-hidden="true">
+                        @switch (stat.icon) {
+                          @case ('model') {
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2"/><line x1="12" y1="22" x2="12" y2="15.5"/><polyline points="22 8.5 12 15.5 2 8.5"/></svg>
+                          }
+                          @case ('town') {
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                          }
+                          @default {
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                          }
+                        }
+                      </div>
+                      <div class="stat-tile-text">
+                        <span class="stat-tile-label">{{ t(stat.labelKey) }}</span>
+                        <strong class="stat-tile-value">{{ stat.value }}</strong>
+                      </div>
                     </div>
-                    <div class="stat-tile-text">
-                      <span class="stat-tile-label">{{ t('models_count') }}</span>
-                      <strong class="stat-tile-value">{{ mlModels.length }}</strong>
-                    </div>
-                  </div>
-
-                  <div class="stat-tile">
-                    <div class="stat-tile-icon" aria-hidden="true">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
-                    </div>
-                    <div class="stat-tile-text">
-                      <span class="stat-tile-label">{{ t('towns_count') }}</span>
-                      <strong class="stat-tile-value">{{ towns.length }}</strong>
-                    </div>
-                  </div>
-
-                  <div class="stat-tile">
-                    <div class="stat-tile-icon" aria-hidden="true">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-                    </div>
-                    <div class="stat-tile-text">
-                      <span class="stat-tile-label">{{ t('flat_types_count') }}</span>
-                      <strong class="stat-tile-value">{{ flatModels.length }}</strong>
-                    </div>
-                  </div>
+                  }
                 </div>
 
                 <p class="caption">{{ t('intro_caption') }}</p>
@@ -102,104 +98,105 @@
               <h2 id="form-heading" class="section-title">{{ t('prediction_form') }}</h2>
 
               <form
-                (submit)="$event.preventDefault(); onSubmit()"
+                [formGroup]="predictionForm"
+                (ngSubmit)="onSubmit()"
                 novalidate
               >
-                <div class="form-grid">
-                  <div class="field-group">
-                    <label class="field-label" for="field-ml-model">{{ t('ml_model') }}</label>
-                    <app-combobox
-                      inputId="field-ml-model"
-                      [formField]="predictionForm.mlModel"
-                      [options]="mlModelOptions()"
-                      [placeholder]="t('ml_model')"
-                      [ariaLabel]="t('ml_model')"
-                      [noMatchesLabel]="t('combobox_no_matches')"
-                      [toggleLabel]="t('toggle_options')"
-                    ></app-combobox>
-                  </div>
+                <div class="form-grid material-form-grid">
+                  <mat-form-field class="field-group" appearance="outline">
+                    <mat-label>{{ t('ml_model') }}</mat-label>
+                    <mat-select
+                      id="field-ml-model"
+                      formControlName="ml_model"
+                      [attr.aria-label]="t('ml_model')"
+                    >
+                      @for (option of mlModelOptions(); track option.value) {
+                        <mat-option [value]="option.value">{{ option.label }}</mat-option>
+                      }
+                    </mat-select>
+                  </mat-form-field>
 
-                  <div class="field-group">
-                    <label class="field-label" for="field-town">{{ t('town') }}</label>
-                    <app-combobox
-                      inputId="field-town"
-                      [formField]="predictionForm.town"
-                      [options]="townOptions()"
-                      [placeholder]="t('town')"
-                      [ariaLabel]="t('town')"
-                      [noMatchesLabel]="t('combobox_no_matches')"
-                      [toggleLabel]="t('toggle_options')"
-                    ></app-combobox>
-                  </div>
+                  <mat-form-field class="field-group" appearance="outline">
+                    <mat-label>{{ t('town') }}</mat-label>
+                    <mat-select
+                      id="field-town"
+                      formControlName="town"
+                      [attr.aria-label]="t('town')"
+                    >
+                      @for (option of townOptions(); track option.value) {
+                        <mat-option [value]="option.value">{{ option.label }}</mat-option>
+                      }
+                    </mat-select>
+                  </mat-form-field>
 
-                  <div class="field-group">
-                    <label class="field-label" for="field-storey-range">{{ t('storey_range') }}</label>
-                    <app-combobox
-                      inputId="field-storey-range"
-                      [formField]="predictionForm.storeyRange"
-                      [options]="storeyRangeOptions()"
-                      [placeholder]="t('storey_range')"
-                      [ariaLabel]="t('storey_range')"
-                      [noMatchesLabel]="t('combobox_no_matches')"
-                      [toggleLabel]="t('toggle_options')"
-                    ></app-combobox>
-                  </div>
+                  <mat-form-field class="field-group" appearance="outline">
+                    <mat-label>{{ t('storey_range') }}</mat-label>
+                    <mat-select
+                      id="field-storey-range"
+                      formControlName="storey_range"
+                      [attr.aria-label]="t('storey_range')"
+                    >
+                      @for (option of storeyRangeOptions(); track option.value) {
+                        <mat-option [value]="option.value">{{ option.label }}</mat-option>
+                      }
+                    </mat-select>
+                  </mat-form-field>
 
-                  <div class="field-group">
-                    <label class="field-label" for="field-flat-model">{{ t('flat_model') }}</label>
-                    <app-combobox
-                      inputId="field-flat-model"
-                      [formField]="predictionForm.flatModel"
-                      [options]="flatModelOptions()"
-                      [placeholder]="t('flat_model')"
-                      [ariaLabel]="t('flat_model')"
-                      [noMatchesLabel]="t('combobox_no_matches')"
-                      [toggleLabel]="t('toggle_options')"
-                    ></app-combobox>
-                  </div>
+                  <mat-form-field class="field-group" appearance="outline">
+                    <mat-label>{{ t('flat_model') }}</mat-label>
+                    <mat-select
+                      id="field-flat-model"
+                      formControlName="flat_model"
+                      [attr.aria-label]="t('flat_model')"
+                    >
+                      @for (option of flatModelOptions(); track option.value) {
+                        <mat-option [value]="option.value">{{ option.label }}</mat-option>
+                      }
+                    </mat-select>
+                  </mat-form-field>
 
-                  <div class="field-group field-full">
-                    <label class="field-label" for="field-floor-area">{{ t('floor_area') }}</label>
-                    <app-number-field
-                      inputId="field-floor-area"
-                      [formField]="predictionForm.floorAreaSqm"
-                      [step]="1"
-                      [unit]="t('floor_area_unit_short')"
+                  <mat-form-field class="field-group field-full" appearance="outline">
+                    <mat-label>{{ t('floor_area') }}</mat-label>
+                    <input
+                      matInput
+                      id="field-floor-area"
+                      type="number"
+                      formControlName="floor_area_sqm"
+                      [attr.aria-label]="t('floor_area')"
                       [placeholder]="t('enter_floor_area')"
-                      [ariaLabel]="t('floor_area')"
-                      [ariaDescribedby]="floorAreaErrorId()"
-                      [decreaseLabel]="t('decrease_value')"
-                      [increaseLabel]="t('increase_value')"
-                    ></app-number-field>
-                    @if (floorAreaRequiredError()) {
-                      <span id="floor-area-error" class="field-error">{{ t('missing_floor_area') }}</span>
-                    } @else if (floorAreaRangeError()) {
-                      <span id="floor-area-error" class="field-error">{{ t('floor_area_range') }}</span>
+                      min="20"
+                      max="300"
+                      step="1"
+                    />
+                    <span matTextSuffix>{{ t('floor_area_unit_short') }}</span>
+                    @if (showFloorAreaRequiredError()) {
+                      <mat-error>{{ t('missing_floor_area') }}</mat-error>
+                    } @else if (showFloorAreaRangeError()) {
+                      <mat-error>{{ t('floor_area_range') }}</mat-error>
                     }
-                  </div>
+                  </mat-form-field>
 
-                  <div class="field-group field-full">
-                    <label class="field-label" for="field-lease-year">{{ t('lease_commence_date') }}</label>
-                    <app-combobox
-                      inputId="field-lease-year"
-                      [formField]="predictionForm.leaseCommenceYear"
-                      [options]="leaseYearOptions()"
-                      [placeholder]="t('lease_commence_date')"
-                      [ariaLabel]="t('lease_commence_date')"
-                      [ariaDescribedby]="leaseYearErrorId()"
-                      [noMatchesLabel]="t('combobox_no_matches')"
-                      [toggleLabel]="t('toggle_options')"
-                    ></app-combobox>
-                    @if (leaseYearRangeError()) {
-                      <span id="lease-year-error" class="field-error">{{ leaseYearRangeMessage() }}</span>
+                  <mat-form-field class="field-group field-full" appearance="outline">
+                    <mat-label>{{ t('lease_commence_date') }}</mat-label>
+                    <mat-select
+                      id="field-lease-year"
+                      formControlName="lease_commence_year"
+                      [attr.aria-label]="t('lease_commence_date')"
+                    >
+                      @for (year of leaseYears; track year) {
+                        <mat-option [value]="year">{{ year }}</mat-option>
+                      }
+                    </mat-select>
+                    @if (showLeaseYearRangeError()) {
+                      <mat-error>{{ leaseYearRangeMessage() }}</mat-error>
                     }
-                  </div>
+                  </mat-form-field>
 
                   <div class="button-row field-full">
                     <button
                       class="btn-primary"
                       type="submit"
-                      [disabled]="predictionForm().invalid() || loading()"
+                      [disabled]="predictionForm.invalid || loading()"
                       [attr.aria-keyshortcuts]="isMac() ? 'Meta+Enter' : 'Control+Enter'"
                     >
                       <span [class.loading-pulse]="loading()">
@@ -248,13 +245,13 @@
 
               <div
                 class="price-panel"
-                [class.price-panel-glow]="hasPrediction()"
+                [class.price-panel-glow]="hasResult()"
               >
                 <div class="price-panel-inner">
                   <span class="price-label">{{ t('prediction') }}</span>
-                  @if (hasPrediction()) {
+                  @if (hasResult()) {
                     <strong class="price-value has-value">
-                      {{ formatCurrency(predictedPrice()) }}
+                      {{ predictedPrice() | currency: 'SGD' : 'symbol' : '1.0-0' : priceLocale() }}
                     </strong>
                   } @else if (loading()) {
                     <strong class="price-value awaiting">
@@ -304,7 +301,7 @@
 
             <!-- Chart area -->
             <div class="chart-shell">
-              @if (hasPrediction()) {
+              @if (hasResult()) {
                 <div class="chart-header">
                   <div class="chart-copy">
                     <span class="chart-kicker">{{ t('predicted_trends') }}</span>
@@ -314,7 +311,7 @@
                   <div class="chart-summary-grid">
                     <div class="chart-summary-card">
                       <span class="chart-summary-label">{{ t('chart_latest') }}</span>
-                      <strong class="chart-summary-value">{{ formatCurrency(chartMetrics().latestValue) }}</strong>
+                      <strong class="chart-summary-value">{{ formatChartCurrency(chartMetrics().latestValue) }}</strong>
                     </div>
                     <div class="chart-summary-card">
                       <span class="chart-summary-label">{{ t('chart_range') }}</span>
@@ -337,17 +334,23 @@
                   </div>
                 </div>
 
-                @if (isBrowser) {
-                  <div class="chart-frame">
-                    <canvas
-                      baseChart
-                      [type]="'line'"
-                      [data]="chartData()"
-                      [options]="chartOptions()"
-                      [plugins]="chartPlugins"
-                    ></canvas>
-                  </div>
-                } @else {
+                @defer (when hasResult()) {
+                  @if (isBrowser) {
+                    <div class="chart-frame">
+                      <canvas
+                        baseChart
+                        [type]="'line'"
+                        [data]="chartData()"
+                        [options]="chartOptions()"
+                        [plugins]="chartPlugins"
+                      ></canvas>
+                    </div>
+                  } @else {
+                    <div class="chart-frame chart-frame-placeholder">
+                      <span class="chart-summary-label">{{ t('loading_chart') }}</span>
+                    </div>
+                  }
+                } @placeholder {
                   <div class="chart-frame chart-frame-placeholder">
                     <span class="chart-summary-label">{{ t('loading_chart') }}</span>
                   </div>
@@ -355,12 +358,9 @@
               } @else {
                 <div class="chart-empty">
                   <div class="empty-chart-bars" aria-hidden="true">
-                    <div class="empty-bar" style="--bar-h:35%"></div>
-                    <div class="empty-bar" style="--bar-h:55%"></div>
-                    <div class="empty-bar" style="--bar-h:85%"></div>
-                    <div class="empty-bar" style="--bar-h:45%"></div>
-                    <div class="empty-bar" style="--bar-h:70%"></div>
-                    <div class="empty-bar" style="--bar-h:30%"></div>
+                    @for (bar of ['35%', '55%', '85%', '45%', '70%', '30%']; track bar) {
+                      <div class="empty-bar" [style.--bar-h]="bar"></div>
+                    }
                   </div>
                   <h3 class="empty-heading">{{ t('results_placeholder_title') }}</h3>
                   <p class="empty-body">{{ t('results_placeholder_body') }}</p>

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -226,7 +226,7 @@
                   <span class="price-label">{{ t('prediction') }}</span>
                   @if (hasResult()) {
                     <strong class="price-value has-value">
-                      {{ predictedPrice() | currency: 'SGD' : 'symbol' : '1.0-0' : priceLocale() }}
+                      {{ predictedPrice() | currency: 'SGD' : 'symbol-narrow' : '1.0-0' : priceLocale() }}
                     </strong>
                   } @else if (loading()) {
                     <strong class="price-value awaiting">
@@ -311,16 +311,11 @@
 
                 @defer (on viewport) {
                   @if (isBrowser) {
-                    <div class="chart-frame">
-                      <canvas
-                        #chart
-                        baseChart
-                        [type]="'line'"
-                        [data]="chartData()"
-                        [options]="chartOptions()"
-                        [plugins]="chartPlugins"
-                      ></canvas>
-                    </div>
+                    <app-prediction-chart
+                      [data]="chartData()"
+                      [options]="chartOptions()"
+                      [plugins]="chartPlugins"
+                    />
                   } @else {
                     <div class="chart-frame chart-frame-placeholder">
                       <span class="chart-summary-label">{{ t('loading_chart') }}</span>

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -105,11 +105,7 @@
                 <div class="form-grid material-form-grid">
                   <mat-form-field class="field-group" appearance="outline">
                     <mat-label>{{ t('ml_model') }}</mat-label>
-                    <mat-select
-                      id="field-ml-model"
-                      formControlName="ml_model"
-                      [attr.aria-label]="t('ml_model')"
-                    >
+                    <mat-select id="field-ml-model" formControlName="ml_model">
                       @for (option of mlModelOptions(); track option.value) {
                         <mat-option [value]="option.value">{{ option.label }}</mat-option>
                       }
@@ -118,11 +114,7 @@
 
                   <mat-form-field class="field-group" appearance="outline">
                     <mat-label>{{ t('town') }}</mat-label>
-                    <mat-select
-                      id="field-town"
-                      formControlName="town"
-                      [attr.aria-label]="t('town')"
-                    >
+                    <mat-select id="field-town" formControlName="town">
                       @for (option of townOptions(); track option.value) {
                         <mat-option [value]="option.value">{{ option.label }}</mat-option>
                       }
@@ -131,11 +123,7 @@
 
                   <mat-form-field class="field-group" appearance="outline">
                     <mat-label>{{ t('storey_range') }}</mat-label>
-                    <mat-select
-                      id="field-storey-range"
-                      formControlName="storey_range"
-                      [attr.aria-label]="t('storey_range')"
-                    >
+                    <mat-select id="field-storey-range" formControlName="storey_range">
                       @for (option of storeyRangeOptions(); track option.value) {
                         <mat-option [value]="option.value">{{ option.label }}</mat-option>
                       }
@@ -144,11 +132,7 @@
 
                   <mat-form-field class="field-group" appearance="outline">
                     <mat-label>{{ t('flat_model') }}</mat-label>
-                    <mat-select
-                      id="field-flat-model"
-                      formControlName="flat_model"
-                      [attr.aria-label]="t('flat_model')"
-                    >
+                    <mat-select id="field-flat-model" formControlName="flat_model">
                       @for (option of flatModelOptions(); track option.value) {
                         <mat-option [value]="option.value">{{ option.label }}</mat-option>
                       }
@@ -162,7 +146,6 @@
                       id="field-floor-area"
                       type="number"
                       formControlName="floor_area_sqm"
-                      [attr.aria-label]="t('floor_area')"
                       [placeholder]="t('enter_floor_area')"
                       min="20"
                       max="300"
@@ -178,11 +161,7 @@
 
                   <mat-form-field class="field-group field-full" appearance="outline">
                     <mat-label>{{ t('lease_commence_date') }}</mat-label>
-                    <mat-select
-                      id="field-lease-year"
-                      formControlName="lease_commence_year"
-                      [attr.aria-label]="t('lease_commence_date')"
-                    >
+                    <mat-select id="field-lease-year" formControlName="lease_commence_year">
                       @for (year of leaseYears; track year) {
                         <mat-option [value]="year">{{ year }}</mat-option>
                       }
@@ -334,7 +313,7 @@
                   </div>
                 </div>
 
-                @defer (when showChart()) {
+                @defer (on viewport) {
                   @if (isBrowser) {
                     <div class="chart-frame">
                       <canvas

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -313,6 +313,7 @@
                   @if (isBrowser) {
                     <div class="chart-frame">
                       <canvas
+                        #chart
                         baseChart
                         [type]="'line'"
                         [data]="chartData()"

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -245,7 +245,7 @@
 
               <div
                 class="price-panel"
-                [class.price-panel-glow]="hasResult()"
+                [class.price-panel-glow]="hasPrediction()"
               >
                 <div class="price-panel-inner">
                   <span class="price-label">{{ t('prediction') }}</span>
@@ -301,7 +301,7 @@
 
             <!-- Chart area -->
             <div class="chart-shell">
-              @if (hasResult()) {
+              @if (showChart()) {
                 <div class="chart-header">
                   <div class="chart-copy">
                     <span class="chart-kicker">{{ t('predicted_trends') }}</span>
@@ -334,7 +334,7 @@
                   </div>
                 </div>
 
-                @defer (when hasResult()) {
+                @defer (when showChart()) {
                   @if (isBrowser) {
                     <div class="chart-frame">
                       <canvas

--- a/src/app/prediction-tool/prediction-tool.component.html
+++ b/src/app/prediction-tool/prediction-tool.component.html
@@ -58,11 +58,7 @@
                 <p class="lead">{{ t('intro_blurb') }}</p>
 
                 <div class="figure-row">
-                  @for (stat of [
-                    { labelKey: 'models_count', value: mlModels.length, icon: 'model' },
-                    { labelKey: 'towns_count', value: towns.length, icon: 'town' },
-                    { labelKey: 'flat_types_count', value: flatModels.length, icon: 'flat' }
-                  ]; track stat.labelKey) {
+                  @for (stat of stats(); track stat.labelKey) {
                     <div class="stat-tile">
                       <div class="stat-tile-icon" aria-hidden="true">
                         @switch (stat.icon) {

--- a/src/app/prediction-tool/prediction-tool.component.spec.ts
+++ b/src/app/prediction-tool/prediction-tool.component.spec.ts
@@ -36,17 +36,17 @@ describe('PredictionToolComponent', () => {
       .toContain('Awaiting prediction');
   });
 
-  it('should reset form interaction state via predictionForm().reset()', async () => {
+  it('should reset form interaction state when reset is clicked', async () => {
     await fixture.whenStable();
     const form = component['predictionForm'];
 
-    form().markAsTouched();
-    expect(form().touched()).toBe(true);
+    form.markAllAsTouched();
+    expect(form.touched).toBe(true);
 
     const compiled = fixture.nativeElement as HTMLElement;
     compiled.querySelector<HTMLButtonElement>('.btn-reset')?.click();
     await fixture.whenStable();
 
-    expect(form().touched()).toBe(false);
+    expect(form.touched).toBe(false);
   });
 });

--- a/src/app/prediction-tool/prediction-tool.component.spec.ts
+++ b/src/app/prediction-tool/prediction-tool.component.spec.ts
@@ -1,9 +1,20 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PredictionToolComponent } from './prediction-tool.component';
+import { PredictionService, type ApiResponse } from '../services/prediction.service';
+
+const MOCK_RESPONSE: ApiResponse = {
+  predictions: [
+    { month: '2024-12', predictedPrice: 420000 },
+    { month: '2025-01', predictedPrice: 500000 }
+  ]
+};
+
+// Each test can swap this to control how the mocked service resolves/rejects.
+let mockFetch: (payload: unknown) => Promise<ApiResponse>;
 
 describe('PredictionToolComponent', () => {
   let component: PredictionToolComponent;
@@ -11,9 +22,20 @@ describe('PredictionToolComponent', () => {
 
   beforeEach(async () => {
     localStorage.clear();
+    mockFetch = async () => MOCK_RESPONSE;
+
     await TestBed.configureTestingModule({
       imports: [PredictionToolComponent],
-      providers: [provideZonelessChangeDetection(), provideHttpClient()]
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        {
+          provide: PredictionService,
+          useValue: {
+            fetchPrediction: (payload: unknown) => mockFetch(payload)
+          }
+        }
+      ]
     })
     .compileComponents();
 
@@ -48,5 +70,42 @@ describe('PredictionToolComponent', () => {
     await fixture.whenStable();
 
     expect(form.touched).toBe(false);
+  });
+
+  it('should display the resolved prediction after submitting', async () => {
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    await component['onSubmit']();
+
+    await vi.waitFor(async () => {
+      await fixture.whenStable();
+      expect(compiled.querySelector('.price-value.has-value')).toBeTruthy();
+    });
+
+    // The latest prediction (500000) drives the headline price; assert the
+    // resolved-status path actually populated the results panel.
+    expect(compiled.querySelector('.price-value.has-value')?.textContent)
+      .toMatch(/500,?000/);
+    expect(compiled.querySelector('.price-value.awaiting')).toBeNull();
+  });
+
+  it('should surface an error message when the request fails', async () => {
+    mockFetch = async () => {
+      throw new Error('prediction failed');
+    };
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    await component['onSubmit']();
+
+    await vi.waitFor(async () => {
+      await fixture.whenStable();
+      expect(compiled.querySelector('.error-display')).toBeTruthy();
+    });
+
+    expect(compiled.querySelector('.error-display')?.textContent?.trim().length)
+      .toBeGreaterThan(0);
+    expect(compiled.querySelector('.price-value.has-value')).toBeNull();
   });
 });

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -1,5 +1,9 @@
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import {
+  CurrencyPipe,
+  DOCUMENT,
+  formatCurrency,
+  isPlatformBrowser
+} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -9,92 +13,91 @@ import {
   computed,
   effect,
   inject,
+  resource,
   signal,
   viewChild
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
 import { BaseChartDirective } from 'ng2-charts';
 import type { ChartConfiguration } from 'chart.js';
-import { Temporal } from '@js-temporal/polyfill';
-import { firstValueFrom } from 'rxjs';
-import { FormField, form, max, min, required, submit, validate } from '@angular/forms/signals';
 
 import {
   flat_model_list,
   ml_model_list,
-  month_list,
   storey_range_list,
   town_list
 } from '../lists';
+import {
+  MAX_FLOOR_AREA,
+  MAX_YEAR,
+  MIN_FLOOR_AREA,
+  MIN_YEAR,
+  PredictionService,
+  buildPredictionRequestPayload,
+  clampNumber,
+  coerceOption,
+  createDefaultTrendData,
+  normalizeTrendData,
+  roundValue,
+  sanitizeCurrencyValue,
+  type ApiResponse,
+  type FlatModel,
+  type MlModel,
+  type PredictionRequestPayload,
+  type StoreyRange,
+  type Town,
+  type TrendPoint
+} from '../services/prediction.service';
 import { StorageService } from '../services/storage.service';
 import {
   TranslationService
 } from '../services/translation.service';
 import type { OptionGroup } from '../services/translation.service';
-import { ComboboxComponent } from './combobox/combobox.component';
-import { NumberFieldComponent } from './number-field/number-field.component';
-
-type MlModel = (typeof ml_model_list)[number];
-type Town = (typeof town_list)[number];
-type StoreyRange = (typeof storey_range_list)[number];
-type FlatModel = (typeof flat_model_list)[number];
+import { integerValidator } from './prediction-form.validators';
 
 type PredictionFormValue = {
-  mlModel: MlModel;
+  ml_model: MlModel;
   town: Town;
-  storeyRange: StoreyRange;
-  flatModel: FlatModel;
-  // null represents an empty/cleared input; the required validator flags it.
-  floorAreaSqm: number | null;
-  // string because the combobox value model is always a string.
-  leaseCommenceYear: string;
+  storey_range: StoreyRange;
+  flat_model: FlatModel;
+  floor_area_sqm: number | null;
+  lease_commence_year: number | null;
 };
 
-// leaseCommenceYear is stored as a number here (clamped from the string form
-// value) so the template can render it directly without further conversion.
-type SummaryValues = {
-  mlModel: MlModel;
-  town: Town;
-  leaseCommenceYear: number;
+type StoredPredictionFormValue = {
+  mlModel?: MlModel;
+  ml_model?: MlModel;
+  town?: Town;
+  storeyRange?: StoreyRange;
+  storey_range?: StoreyRange;
+  flatModel?: FlatModel;
+  flat_model?: FlatModel;
+  floorAreaSqm?: number | null;
+  floor_area_sqm?: number | null;
+  leaseCommenceYear?: number | string | null;
+  lease_commence_year?: number | null;
 };
 
-type TrendPoint = {
-  label: string;
-  value: number;
+type PredictionRequestTrigger = {
+  seq: number;
+  payload: PredictionRequestPayload;
 };
-
-type ApiResponse = {
-  predictions: Array<{
-    month: string;
-    predictedPrice: number;
-  }>;
-};
-
-type PredictionRequestPayload = {
-  model: MlModel;
-  monthStart: string;
-  monthEnd: string;
-  town: Town;
-  storeyRange: StoreyRange;
-  flatModel: FlatModel;
-  floorAreaSqm: string;
-  leaseCommenceYear: string;
-};
-
-const MIN_YEAR = 1960;
-const MAX_YEAR = Temporal.PlainYearMonth.from(month_list[month_list.length - 1]).year;
-const MIN_FLOOR_AREA = 20;
-const MAX_FLOOR_AREA = 300;
-const PREDICTION_API_URL =
-  'https://ee4802-g20-tool-ng.shenghaoc.workers.dev/api/prices';
-const PREDICTION_MONTHS = [...month_list.slice(-13)];
 
 const INITIAL_FORM_VALUE: PredictionFormValue = {
-  mlModel: ml_model_list[0],
+  ml_model: ml_model_list[0],
   town: town_list[0],
-  storeyRange: storey_range_list[0],
-  flatModel: flat_model_list[0],
-  floorAreaSqm: MIN_FLOOR_AREA,
-  leaseCommenceYear: String(MAX_YEAR)
+  storey_range: storey_range_list[0],
+  flat_model: flat_model_list[0],
+  floor_area_sqm: MIN_FLOOR_AREA,
+  lease_commence_year: MAX_YEAR
 };
 
 @Component({
@@ -106,18 +109,21 @@ const INITIAL_FORM_VALUE: PredictionFormValue = {
     '(document:keydown)': 'onDocumentKeyDown($event)'
   },
   imports: [
-    FormField,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatInputModule,
     BaseChartDirective,
-    ComboboxComponent,
-    NumberFieldComponent
+    CurrencyPipe
   ]
 })
 export class PredictionToolComponent implements OnInit {
   protected readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly document = inject(DOCUMENT);
   private readonly storageService = inject(StorageService);
-  private readonly http = inject(HttpClient);
+  private readonly predictionService = inject(PredictionService);
   private readonly translationService = inject(TranslationService);
+  private readonly fb = inject(FormBuilder);
 
   protected readonly chart = viewChild(BaseChartDirective);
   protected readonly resultsAnchor = viewChild<ElementRef<HTMLElement>>('resultsAnchor');
@@ -134,18 +140,46 @@ export class PredictionToolComponent implements OnInit {
   );
 
   protected readonly mounted = signal(false);
-  protected readonly loading = signal(false);
   protected readonly darkMode = signal(false);
   protected readonly isMac = signal(false);
-  protected readonly errorMessage = signal('');
   protected readonly hasPrediction = signal(false);
   protected readonly liveMessage = signal('');
-  protected readonly trendData = signal<TrendPoint[]>(
-    createDefaultTrendData()
+  protected readonly errorMessage = signal('');
+
+  private readonly predictionRequest = signal<PredictionRequestTrigger | undefined>(
+    undefined
+  );
+  private predictionRequestSeq = 0;
+  private lastAnnouncedSeq = -1;
+
+  protected readonly predictionResource = resource({
+    params: () => this.predictionRequest(),
+    loader: async ({ params: request }) => {
+      if (!request) {
+        return undefined;
+      }
+      return this.predictionService.fetchPrediction(request.payload);
+    }
+  });
+
+  protected readonly loading = computed(
+    () =>
+      this.predictionResource.isLoading() ||
+      this.predictionResource.status() === 'reloading'
   );
 
-  // Cached theme colors to avoid calling getComputedStyle in computed properties.
-  // Only read by the chartData/chartOptions computed signals, never the template.
+  protected readonly hasResult = computed(
+    () => this.hasPrediction() && this.predictionResource.hasValue()
+  );
+
+  protected readonly trendData = computed<TrendPoint[]>(() => {
+    const response = this.predictionResource.value();
+    if (response) {
+      return normalizeTrendData(response);
+    }
+    return createDefaultTrendData();
+  });
+
   private readonly themeColors = signal({
     primary: '',
     chartFill: '',
@@ -186,8 +220,8 @@ export class PredictionToolComponent implements OnInit {
     }))
   );
 
-  protected readonly leaseYearOptions = computed(() =>
-    this.leaseYears.map((y) => ({ value: String(y), label: String(y) }))
+  protected readonly priceLocale = computed(() =>
+    this.lang() === 'zh' ? 'zh-SG' : 'en-SG'
   );
 
   protected readonly predictedPrice = computed(() => {
@@ -237,9 +271,6 @@ export class PredictionToolComponent implements OnInit {
     };
   });
 
-  // Chart plugin color cache: updated once in ngOnInit and on every theme toggle.
-  // The plugin array is stable (never recreated), so Chart.js doesn't re-register
-  // plugins on each theme change.
   private readonly chartColors = { c1: '', c2: '', glow: '' };
 
   protected readonly chartPlugins = [
@@ -250,8 +281,6 @@ export class PredictionToolComponent implements OnInit {
         if (!chartArea || !data.datasets[0]) return;
         const c1 = this.chartColors.c1;
         const c2 = this.chartColors.c2;
-        // Guard: colors are empty strings until updateChartColorsCache() runs;
-        // addColorStop throws a DOMException with an empty/invalid color value.
         if (!c1 || !c2) return;
         const gradient = ctx.createLinearGradient(chartArea.left, 0, chartArea.right, 0);
         gradient.addColorStop(0, c1);
@@ -263,7 +292,6 @@ export class PredictionToolComponent implements OnInit {
       id: 'latestGlow',
       afterDatasetsDraw: (chart: any) => {
         const { ctx } = chart;
-        // Guard: glow is '' until updateChartColorsCache() runs.
         if (!this.chartColors.glow) return;
         const meta = chart.getDatasetMeta(0);
         if (!meta || !meta.data || meta.data.length === 0) return;
@@ -306,7 +334,7 @@ export class PredictionToolComponent implements OnInit {
           callbacks: {
             label: (context) => {
               const value = Number(context.raw ?? 0);
-              return formatCurrency(value);
+              return this.formatChartCurrency(value);
             }
           }
         }
@@ -330,15 +358,12 @@ export class PredictionToolComponent implements OnInit {
           }
         },
         y: {
-          // grace adds padding above/below the data range so the line is
-          // never squashed against the top or bottom of the chart area.
           grace: '15%',
           grid: {
             color: (context: any) =>
               context.index === 0 ? colors.gridColor : colors.dashedGridColor,
             lineWidth: 1,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            borderDash: ((context: any) => context.index === 0 ? [] : [3, 4]) as any,
+            borderDash: ((context: any) => (context.index === 0 ? [] : [3, 4])) as any,
             drawBorder: false
           },
           ticks: {
@@ -350,72 +375,100 @@ export class PredictionToolComponent implements OnInit {
     };
   });
 
-  private readonly predictionModel = signal<PredictionFormValue>({ ...INITIAL_FORM_VALUE });
-
-  protected readonly predictionForm = form(this.predictionModel, (s) => {
-    required(s.mlModel);
-    required(s.town);
-    required(s.storeyRange);
-    required(s.flatModel);
-    required(s.floorAreaSqm);
-    min(s.floorAreaSqm, MIN_FLOOR_AREA);
-    max(s.floorAreaSqm, MAX_FLOOR_AREA);
-    required(s.leaseCommenceYear);
-    validate(s.leaseCommenceYear, ({ value }) => {
-      const n = Number(value());
-      if (!Number.isFinite(n) || n < MIN_YEAR || n > MAX_YEAR) {
-        return { kind: 'range' };
+  protected readonly predictionForm = this.fb.group({
+    ml_model: this.fb.nonNullable.control<MlModel>(INITIAL_FORM_VALUE.ml_model, {
+      validators: Validators.required
+    }),
+    town: this.fb.nonNullable.control<Town>(INITIAL_FORM_VALUE.town, {
+      validators: Validators.required
+    }),
+    storey_range: this.fb.nonNullable.control<StoreyRange>(
+      INITIAL_FORM_VALUE.storey_range,
+      { validators: Validators.required }
+    ),
+    flat_model: this.fb.nonNullable.control<FlatModel>(
+      INITIAL_FORM_VALUE.flat_model,
+      { validators: Validators.required }
+    ),
+    floor_area_sqm: this.fb.control<number | null>(
+      INITIAL_FORM_VALUE.floor_area_sqm,
+      {
+        validators: [
+          Validators.required,
+          Validators.min(MIN_FLOOR_AREA),
+          Validators.max(MAX_FLOOR_AREA),
+          integerValidator
+        ]
       }
-      return undefined;
-    });
+    ),
+    lease_commence_year: this.fb.control<number | null>(
+      INITIAL_FORM_VALUE.lease_commence_year,
+      {
+        validators: [
+          Validators.required,
+          Validators.min(MIN_YEAR),
+          Validators.max(MAX_YEAR)
+        ]
+      }
+    )
   });
 
   protected readonly summaryValues = computed<SummaryValues>(() => {
-    const value = this.predictionModel();
+    const value = this.predictionForm.getRawValue();
     return {
-      mlModel: coerceOption(value.mlModel, ml_model_list),
+      mlModel: coerceOption(value.ml_model, ml_model_list),
       town: coerceOption(value.town, town_list),
-      leaseCommenceYear: clampNumber(value.leaseCommenceYear, MIN_YEAR, MAX_YEAR, MAX_YEAR)
+      leaseCommenceYear: clampNumber(
+        value.lease_commence_year,
+        MIN_YEAR,
+        MAX_YEAR,
+        MAX_YEAR
+      )
     };
   });
 
-  protected readonly floorAreaErrorId = computed(() => {
-    const state = this.predictionForm.floorAreaSqm();
-    return state.touched() && state.errors().length > 0 ? 'floor-area-error' : null;
-  });
-
-  protected readonly floorAreaRequiredError = computed(() => {
-    const state = this.predictionForm.floorAreaSqm();
-    return state.touched() && state.errors().some(e => e.kind === 'required');
-  });
-
-  protected readonly floorAreaRangeError = computed(() => {
-    const state = this.predictionForm.floorAreaSqm();
-    return state.touched() && state.errors().some(e => e.kind === 'min' || e.kind === 'max');
-  });
-
-  protected readonly leaseYearErrorId = computed(() => {
-    const state = this.predictionForm.leaseCommenceYear();
-    return state.touched() && state.errors().length > 0 ? 'lease-year-error' : null;
-  });
-
-  protected readonly leaseYearRangeError = computed(() => {
-    const state = this.predictionForm.leaseCommenceYear();
-    return state.touched() && state.errors().some(e => e.kind === 'range');
-  });
+  protected readonly leaseYearRangeMessage = computed(() =>
+    this.t('lease_year_range')
+      .replace('{min}', String(MIN_YEAR))
+      .replace('{max}', String(MAX_YEAR))
+  );
 
   constructor() {
-    // Persist form state to localStorage whenever the model changes.
-    // Writing to localStorage is a valid effect use case (imperative side effect).
-    effect(() => {
+    this.predictionForm.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
       if (this.isBrowser) {
-        this.storageService.setItem('predictionFormData', this.predictionModel());
+        this.persistFormState();
+      }
+    });
+
+    effect(() => {
+      const request = this.predictionRequest();
+      const status = this.predictionResource.status();
+
+      if (!request) {
+        return;
+      }
+
+      if (status === 'resolved' && this.predictionResource.hasValue()) {
+        this.hasPrediction.set(true);
+        this.errorMessage.set('');
+        this.chart()?.update();
+
+        if (request.seq !== this.lastAnnouncedSeq) {
+          this.lastAnnouncedSeq = request.seq;
+          this.announcePredictionComplete(this.predictionResource.value()!);
+        }
+        return;
+      }
+
+      if (status === 'error') {
+        const error = this.predictionResource.error();
+        console.error('Prediction request failed', { error, request: request.payload });
+        this.errorMessage.set(this.t('error_fetch'));
       }
     });
   }
 
   protected onDocumentKeyDown(event: KeyboardEvent): void {
-    // Ignore events already handled by child components (e.g. Escape inside Combobox).
     if (event.defaultPrevented) {
       return;
     }
@@ -430,7 +483,6 @@ export class PredictionToolComponent implements OnInit {
 
     if (event.key === 'Escape' && !this.loading()) {
       const active = this.document.activeElement as HTMLElement | null;
-      // Only reset if focus is within the form area (not a combobox dropdown, etc.)
       if (active && active.closest('form')) {
         this.resetForm();
       }
@@ -453,111 +505,66 @@ export class PredictionToolComponent implements OnInit {
     }
   }
 
-  // navigator.userAgent contains "Mac OS X" on iOS too ("... like Mac OS X"),
-  // so prefer the modern userAgentData.platform and fall back to a "Macintosh"
-  // check, which real Macs report but iPhones do not.
-  private detectMac(): boolean {
-    const uaData = (
-      navigator as Navigator & { userAgentData?: { platform?: string } }
-    ).userAgentData;
-    if (uaData?.platform) {
-      return uaData.platform === 'macOS';
-    }
-    return navigator.userAgent.includes('Macintosh');
-  }
-
   protected async onSubmit(): Promise<void> {
-    if (!this.isBrowser || this.loading()) return;
+    if (!this.isBrowser || this.loading()) {
+      return;
+    }
 
-    await submit(this.predictionForm, async () => {
-      this.loading.set(true);
-      this.errorMessage.set('');
+    this.predictionForm.markAllAsTouched();
 
-      const formValue = this.predictionModel();
-      const clampedFloorArea = clampNumber(
-        formValue.floorAreaSqm,
-        MIN_FLOOR_AREA,
-        MAX_FLOOR_AREA,
-        MIN_FLOOR_AREA
-      );
+    if (this.predictionForm.invalid) {
+      return;
+    }
 
-      if (clampedFloorArea !== formValue.floorAreaSqm) {
-        this.predictionModel.update(v => ({ ...v, floorAreaSqm: clampedFloorArea }));
-      }
+    const raw = this.predictionForm.getRawValue();
+    const floorArea = clampNumber(
+      raw.floor_area_sqm,
+      MIN_FLOOR_AREA,
+      MAX_FLOOR_AREA,
+      MIN_FLOOR_AREA
+    );
+    const leaseYear = clampNumber(
+      raw.lease_commence_year,
+      MIN_YEAR,
+      MAX_YEAR,
+      MAX_YEAR
+    );
 
-      const predictionWindow = getPredictionWindow();
-      const requestPayload: PredictionRequestPayload = {
-        model: formValue.mlModel,
-        monthStart: predictionWindow.monthStart,
-        monthEnd: predictionWindow.monthEnd,
-        town: formValue.town,
-        storeyRange: formValue.storeyRange,
-        flatModel: formValue.flatModel,
-        floorAreaSqm: clampedFloorArea.toString(),
-        leaseCommenceYear: formValue.leaseCommenceYear.toString()
-      };
-      const formData = createPredictionFormData(requestPayload);
+    if (floorArea !== raw.floor_area_sqm) {
+      this.predictionForm.controls.floor_area_sqm.setValue(floorArea);
+    }
+    if (leaseYear !== raw.lease_commence_year) {
+      this.predictionForm.controls.lease_commence_year.setValue(leaseYear);
+    }
 
-      try {
-        const responseText = await firstValueFrom(
-          this.http.post(PREDICTION_API_URL, formData, { responseType: 'text' })
-        );
-        const serverData = parsePredictionResponse(responseText, requestPayload);
-        const normalizedData = normalizeTrendData(serverData);
-
-        this.hasPrediction.set(true);
-        this.trendData.set(normalizedData);
-        this.chart()?.update();
-
-        const latestValue = normalizedData.at(-1)?.value ?? 0;
-        const priceStr = formatCurrency(sanitizeCurrencyValue(latestValue));
-        const announcement = this.t('prediction_complete').replace('{price}', priceStr);
-        // Clear the live region first so identical consecutive announcements
-        // are still re-read by assistive technology.
-        this.liveMessage.set('');
-        requestAnimationFrame(() => {
-          this.liveMessage.set(announcement);
-          this.resultsAnchor()?.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-          // Focus the results heading for keyboard users, then drop the
-          // temporary tabindex once focus leaves so it isn't left interactive.
-          const heading = this.resultsHeadingEl()?.nativeElement;
-          if (heading) {
-            heading.setAttribute('tabindex', '-1');
-            heading.focus({ preventScroll: true });
-            heading.addEventListener(
-              'blur',
-              () => heading.removeAttribute('tabindex'),
-              { once: true }
-            );
-          }
-        });
-      } catch (error: unknown) {
-        if (error instanceof HttpErrorResponse) {
-          console.error('Prediction request failed', {
-            summary: formatPredictionError(
-              `API request failed with ${error.status} ${error.statusText}`,
-              typeof error.error === 'string' ? error.error : '',
-              requestPayload
-            )
-          });
-        } else {
-          console.error('Prediction request failed', { error, requestPayload });
-        }
-        this.errorMessage.set(this.t('error_fetch'));
-      } finally {
-        this.loading.set(false);
-      }
+    this.errorMessage.set('');
+    const payload = buildPredictionRequestPayload({
+      ml_model: raw.ml_model,
+      town: raw.town,
+      storey_range: raw.storey_range,
+      flat_model: raw.flat_model,
+      floor_area_sqm: floorArea,
+      lease_commence_year: leaseYear
     });
+
+    const seq = ++this.predictionRequestSeq;
+    const current = this.predictionRequest();
+
+    if (current && JSON.stringify(current.payload) === JSON.stringify(payload)) {
+      this.predictionResource.reload();
+      this.predictionRequest.set({ seq, payload });
+    } else {
+      this.predictionRequest.set({ seq, payload });
+    }
   }
 
   protected resetForm(): void {
-    this.predictionModel.set({ ...INITIAL_FORM_VALUE });
-    // Signal Forms API: call the field tree for FieldState, then reset interaction
-    // flags on the form and all descendants (documented as form().reset()).
-    this.predictionForm().reset();
+    this.predictionForm.reset({ ...INITIAL_FORM_VALUE });
+    this.predictionRequest.set(undefined);
+    this.predictionResource.set(undefined);
     this.hasPrediction.set(false);
     this.errorMessage.set('');
-    this.trendData.set(createDefaultTrendData());
+    this.lastAnnouncedSeq = -1;
   }
 
   protected toggleTheme(): void {
@@ -589,37 +596,85 @@ export class PredictionToolComponent implements OnInit {
     return this.translationService.translateOption(group, value);
   }
 
-  protected readonly leaseYearRangeMessage = computed(() =>
-    this.t('lease_year_range')
-      .replace('{min}', String(MIN_YEAR))
-      .replace('{max}', String(MAX_YEAR))
-  );
-
-  protected formatCurrency(value: number): string {
-    return formatCurrency(value);
+  protected formatChartCurrency(value: number): string {
+    return formatCurrency(
+      sanitizeCurrencyValue(value),
+      this.priceLocale(),
+      'SGD',
+      'symbol',
+      '1.0-0'
+    );
   }
 
   protected formatCurrencyRange(lowValue: number, peakValue: number): string {
-    return `${formatCurrency(lowValue)} - ${formatCurrency(peakValue)}`;
+    return `${this.formatChartCurrency(lowValue)} - ${this.formatChartCurrency(peakValue)}`;
   }
 
   protected formatDeltaCurrency(value: number): string {
-    const roundedValue = Math.abs(roundValue(value)).toLocaleString();
+    const roundedValue = Math.abs(roundValue(value));
+    const formatted = formatCurrency(
+      roundedValue,
+      this.priceLocale(),
+      'SGD',
+      'symbol',
+      '1.0-0'
+    );
     const sign = value >= 0 ? '+' : '-';
-    return `${sign}$${roundedValue}`;
+    return `${sign}${formatted}`;
+  }
+
+  protected showFloorAreaRequiredError(): boolean {
+    const control = this.predictionForm.controls.floor_area_sqm;
+    return control.touched && control.hasError('required');
+  }
+
+  protected showFloorAreaRangeError(): boolean {
+    const control = this.predictionForm.controls.floor_area_sqm;
+    return (
+      control.touched &&
+      (control.hasError('min') ||
+        control.hasError('max') ||
+        control.hasError('integer'))
+    );
+  }
+
+  protected showLeaseYearRangeError(): boolean {
+    const control = this.predictionForm.controls.lease_commence_year;
+    return (
+      control.touched &&
+      (control.hasError('min') || control.hasError('max') || control.hasError('required'))
+    );
+  }
+
+  private announcePredictionComplete(response: ApiResponse): void {
+    const normalizedData = normalizeTrendData(response);
+    const latestValue = normalizedData.at(-1)?.value ?? 0;
+    const priceStr = this.formatChartCurrency(latestValue);
+    const announcement = this.t('prediction_complete').replace('{price}', priceStr);
+    this.liveMessage.set('');
+    requestAnimationFrame(() => {
+      this.liveMessage.set(announcement);
+      this.resultsAnchor()?.nativeElement.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest'
+      });
+      const heading = this.resultsHeadingEl()?.nativeElement;
+      if (heading) {
+        heading.setAttribute('tabindex', '-1');
+        heading.focus({ preventScroll: true });
+        heading.addEventListener(
+          'blur',
+          () => heading.removeAttribute('tabindex'),
+          { once: true }
+        );
+      }
+    });
   }
 
   private updateChartColorsCache(): void {
     if (!this.isBrowser) return;
     const doc = this.document;
 
-    // The theme tokens in styles.css are defined with light-dark(), which
-    // getComputedStyle().getPropertyValue() returns *unresolved* (the literal
-    // "light-dark(...)" string) for unregistered custom properties. Chart.js
-    // and colorWithAlpha() can't parse that, so resolve each var to a concrete
-    // rgb() value by letting the browser compute it on a throwaway element.
-    // Reads are batched here (init + theme toggle only), not in computed
-    // signals, so this still avoids per-recompute layout thrashing.
     const probe = doc.createElement('span');
     probe.style.display = 'none';
     doc.body.appendChild(probe);
@@ -674,7 +729,7 @@ export class PredictionToolComponent implements OnInit {
 
   private restoreFormState(): void {
     const savedForm =
-      this.storageService.getItem<Partial<PredictionFormValue>>(
+      this.storageService.getItem<StoredPredictionFormValue>(
         'predictionFormData'
       );
 
@@ -682,23 +737,44 @@ export class PredictionToolComponent implements OnInit {
       return;
     }
 
-    this.predictionModel.set({
-      mlModel: coerceOption(savedForm.mlModel, ml_model_list),
+    this.predictionForm.patchValue({
+      ml_model: coerceOption(
+        savedForm.ml_model ?? savedForm.mlModel,
+        ml_model_list
+      ),
       town: coerceOption(savedForm.town, town_list),
-      storeyRange: coerceOption(savedForm.storeyRange, storey_range_list),
-      flatModel: coerceOption(savedForm.flatModel, flat_model_list),
-      floorAreaSqm: clampNumber(
-        savedForm.floorAreaSqm,
+      storey_range: coerceOption(
+        savedForm.storey_range ?? savedForm.storeyRange,
+        storey_range_list
+      ),
+      flat_model: coerceOption(
+        savedForm.flat_model ?? savedForm.flatModel,
+        flat_model_list
+      ),
+      floor_area_sqm: clampNumber(
+        savedForm.floor_area_sqm ?? savedForm.floorAreaSqm,
         MIN_FLOOR_AREA,
         MAX_FLOOR_AREA,
         MIN_FLOOR_AREA
       ),
-      leaseCommenceYear: String(clampNumber(
-        savedForm.leaseCommenceYear,
+      lease_commence_year: clampNumber(
+        savedForm.lease_commence_year ?? savedForm.leaseCommenceYear,
         MIN_YEAR,
         MAX_YEAR,
         MAX_YEAR
-      ))
+      )
+    });
+  }
+
+  private persistFormState(): void {
+    const value = this.predictionForm.getRawValue();
+    this.storageService.setItem('predictionFormData', {
+      mlModel: value.ml_model,
+      town: value.town,
+      storeyRange: value.storey_range,
+      flatModel: value.flat_model,
+      floorAreaSqm: value.floor_area_sqm,
+      leaseCommenceYear: value.lease_commence_year
     });
   }
 
@@ -718,151 +794,23 @@ export class PredictionToolComponent implements OnInit {
       this.darkMode() ? 'dark' : 'light'
     );
   }
-}
 
-function normalizeTrendData(data: ApiResponse): TrendPoint[] {
-  return data.predictions.map((entry) => ({
-    label: entry.month,
-    value: sanitizeCurrencyValue(entry.predictedPrice)
-  }));
-}
-
-function createPredictionFormData(
-  payload: PredictionRequestPayload
-): FormData {
-  const formData = new FormData();
-
-  Object.entries(payload).forEach(([key, value]) => {
-    formData.append(key, value);
-  });
-
-  return formData;
-}
-
-function parsePredictionResponse(
-  responseText: string,
-  requestPayload: PredictionRequestPayload
-): ApiResponse {
-  let parsedResponse: unknown;
-
-  try {
-    parsedResponse = JSON.parse(responseText) as unknown;
-  } catch {
-    throw new Error(
-      formatPredictionError(
-        'API returned invalid JSON',
-        responseText,
-        requestPayload
-      )
-    );
+  private detectMac(): boolean {
+    const uaData = (
+      navigator as Navigator & { userAgentData?: { platform?: string } }
+    ).userAgentData;
+    if (uaData?.platform) {
+      return uaData.platform === 'macOS';
+    }
+    return navigator.userAgent.includes('Macintosh');
   }
-
-  if (
-    !parsedResponse ||
-    typeof parsedResponse !== 'object' ||
-    !('predictions' in parsedResponse) ||
-    !Array.isArray(parsedResponse.predictions) ||
-    parsedResponse.predictions.length === 0
-  ) {
-    throw new Error(
-      formatPredictionError(
-        'API returned an unexpected payload',
-        responseText,
-        requestPayload
-      )
-    );
-  }
-
-  return parsedResponse as ApiResponse;
 }
 
-function formatPredictionError(
-  summary: string,
-  responseText: string,
-  requestPayload: PredictionRequestPayload
-): string {
-  const responsePreview = formatDebugValue(responseText);
-  const requestPreview = JSON.stringify(requestPayload);
-  return `${summary}. Response: ${responsePreview}. Request: ${requestPreview}`;
-}
-
-function formatDebugValue(value: string, maxLength = 280): string {
-  const compactValue = value.replace(/\s+/g, ' ').trim();
-
-  if (!compactValue) {
-    return '(empty response body)';
-  }
-
-  if (compactValue.length <= maxLength) {
-    return compactValue;
-  }
-
-  return `${compactValue.slice(0, maxLength)}...`;
-}
-
-function createDefaultTrendData(): TrendPoint[] {
-  return PREDICTION_MONTHS.map((month) => ({
-    label: month,
-    value: 0
-  }));
-}
-
-function getPredictionWindow(): {
-  monthStart: string;
-  monthEnd: string;
-} {
-  return {
-    monthStart: PREDICTION_MONTHS[0] ?? month_list[0],
-    monthEnd: PREDICTION_MONTHS[PREDICTION_MONTHS.length - 1] ?? month_list[month_list.length - 1]
-  };
-}
-
-function coerceOption<T extends readonly string[]>(
-  value: unknown,
-  options: T
-): T[number] {
-  if (typeof value === 'string' && options.includes(value as T[number])) {
-    return value as T[number];
-  }
-
-  return options[0];
-}
-
-function clampNumber(
-  value: unknown,
-  min: number,
-  max: number,
-  fallback: number
-): number {
-  const n = typeof value === 'number' ? value
-          : typeof value === 'string' ? Number(value)
-          : NaN;
-  if (!Number.isFinite(n)) {
-    return fallback;
-  }
-
-  return Math.min(max, Math.max(min, Math.round(n)));
-}
-
-function sanitizeCurrencyValue(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.max(0, Math.round(value));
-}
-
-function roundValue(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.round(value);
-}
-
-function formatCurrency(value: number): string {
-  return `$${sanitizeCurrencyValue(value).toLocaleString()}`;
-}
+type SummaryValues = {
+  mlModel: MlModel;
+  town: Town;
+  leaseCommenceYear: number;
+};
 
 function colorWithAlpha(color: string, alpha: number): string {
   const trimmed = color.trim();
@@ -878,9 +826,10 @@ function colorWithAlpha(color: string, alpha: number): string {
 
   if (trimmed.startsWith('#')) {
     const hex = trimmed.slice(1);
-    const full = hex.length === 3
-      ? hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
-      : hex;
+    const full =
+      hex.length === 3
+        ? hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+        : hex;
     const r = parseInt(full.slice(0, 2), 16);
     const g = parseInt(full.slice(2, 4), 16);
     const b = parseInt(full.slice(4, 6), 16);

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -26,8 +26,9 @@ import {
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { BaseChartDirective } from 'ng2-charts';
 import type { ChartConfiguration } from 'chart.js';
+
+import { PredictionChartComponent } from './prediction-chart.component';
 
 import {
   flat_model_list,
@@ -107,7 +108,7 @@ const INITIAL_FORM_VALUE: PredictionFormValue = {
     MatFormFieldModule,
     MatSelectModule,
     MatInputModule,
-    BaseChartDirective,
+    PredictionChartComponent,
     CurrencyPipe
   ]
 })
@@ -119,7 +120,6 @@ export class PredictionToolComponent implements OnInit {
   private readonly translationService = inject(TranslationService);
   private readonly fb = inject(FormBuilder);
 
-  protected readonly chart = viewChild<BaseChartDirective>('chart');
   protected readonly resultsAnchor = viewChild<ElementRef<HTMLElement>>('resultsAnchor');
   protected readonly resultsHeadingEl = viewChild<ElementRef<HTMLElement>>('resultsHeading');
 
@@ -454,14 +454,9 @@ export class PredictionToolComponent implements OnInit {
         return;
       }
 
-      if (
-        status === 'resolved' &&
-        this.predictionResource.hasValue() &&
-        request.seq === this.predictionRequest()?.seq
-      ) {
+      if (status === 'resolved' && this.predictionResource.hasValue()) {
         this.hasPrediction.set(true);
         this.errorMessage.set('');
-        this.chart()?.update();
 
         if (request.seq !== this.lastAnnouncedSeq) {
           this.lastAnnouncedSeq = request.seq;
@@ -475,7 +470,7 @@ export class PredictionToolComponent implements OnInit {
         console.error('Prediction request failed', { error, request: request.payload });
         this.errorMessage.set(this.t('error_fetch'));
       }
-    }, { allowSignalWrites: true });
+    });
   }
 
   protected onDocumentKeyDown(event: KeyboardEvent): void {
@@ -562,8 +557,9 @@ export class PredictionToolComponent implements OnInit {
     }
 
     this.syncDocumentState();
+    // Re-reading theme colors updates the `themeColors` signal, which recomputes
+    // chartData/chartOptions; the deferred chart reacts to those input changes.
     this.updateChartColorsCache();
-    this.chart()?.update();
   }
 
   protected toggleLanguage(): void {

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -169,6 +169,14 @@ export class PredictionToolComponent implements OnInit {
   );
 
   protected readonly hasResult = computed(
+    () =>
+      this.hasPrediction() &&
+      this.predictionResource.hasValue() &&
+      !this.loading()
+  );
+
+  /** Keeps chart visible while a subsequent prediction is loading. */
+  protected readonly showChart = computed(
     () => this.hasPrediction() && this.predictionResource.hasValue()
   );
 
@@ -517,45 +525,18 @@ export class PredictionToolComponent implements OnInit {
     }
 
     const raw = this.predictionForm.getRawValue();
-    const floorArea = clampNumber(
-      raw.floor_area_sqm,
-      MIN_FLOOR_AREA,
-      MAX_FLOOR_AREA,
-      MIN_FLOOR_AREA
-    );
-    const leaseYear = clampNumber(
-      raw.lease_commence_year,
-      MIN_YEAR,
-      MAX_YEAR,
-      MAX_YEAR
-    );
-
-    if (floorArea !== raw.floor_area_sqm) {
-      this.predictionForm.controls.floor_area_sqm.setValue(floorArea);
-    }
-    if (leaseYear !== raw.lease_commence_year) {
-      this.predictionForm.controls.lease_commence_year.setValue(leaseYear);
-    }
-
     this.errorMessage.set('');
     const payload = buildPredictionRequestPayload({
       ml_model: raw.ml_model,
       town: raw.town,
       storey_range: raw.storey_range,
       flat_model: raw.flat_model,
-      floor_area_sqm: floorArea,
-      lease_commence_year: leaseYear
+      floor_area_sqm: raw.floor_area_sqm!,
+      lease_commence_year: raw.lease_commence_year!
     });
 
     const seq = ++this.predictionRequestSeq;
-    const current = this.predictionRequest();
-
-    if (current && JSON.stringify(current.payload) === JSON.stringify(payload)) {
-      this.predictionResource.reload();
-      this.predictionRequest.set({ seq, payload });
-    } else {
-      this.predictionRequest.set({ seq, payload });
-    }
+    this.predictionRequest.set({ seq, payload });
   }
 
   protected resetForm(): void {

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -46,7 +46,6 @@ import {
   coerceOption,
   createDefaultTrendData,
   normalizeTrendData,
-  roundValue,
   sanitizeCurrencyValue,
   type ApiResponse,
   type FlatModel,
@@ -157,11 +156,7 @@ export class PredictionToolComponent implements OnInit {
     }
   });
 
-  protected readonly loading = computed(
-    () =>
-      this.predictionResource.isLoading() ||
-      this.predictionResource.status() === 'reloading'
-  );
+  protected readonly loading = this.predictionResource.isLoading;
 
   protected readonly hasResult = computed(
     () =>
@@ -222,6 +217,12 @@ export class PredictionToolComponent implements OnInit {
       label: this.translationService.translateOption('flat_models', f)
     }))
   );
+
+  protected readonly stats = computed(() => [
+    { labelKey: 'models_count', value: this.mlModels.length, icon: 'model' },
+    { labelKey: 'towns_count', value: this.towns.length, icon: 'town' },
+    { labelKey: 'flat_types_count', value: this.flatModels.length, icon: 'flat' }
+  ]);
 
   protected readonly priceLocale = computed(() =>
     this.lang() === 'zh' ? 'zh-SG' : 'en-SG'
@@ -580,8 +581,8 @@ export class PredictionToolComponent implements OnInit {
     return formatCurrency(
       sanitizeCurrencyValue(value),
       this.priceLocale(),
+      '$',
       'SGD',
-      'symbol',
       '1.0-0'
     );
   }
@@ -591,14 +592,7 @@ export class PredictionToolComponent implements OnInit {
   }
 
   protected formatDeltaCurrency(value: number): string {
-    const roundedValue = Math.abs(roundValue(value));
-    const formatted = formatCurrency(
-      roundedValue,
-      this.priceLocale(),
-      'SGD',
-      'symbol',
-      '1.0-0'
-    );
+    const formatted = this.formatChartCurrency(Math.abs(value));
     const sign = value >= 0 ? '+' : '-';
     return `${sign}${formatted}`;
   }

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -119,7 +119,7 @@ export class PredictionToolComponent implements OnInit {
   private readonly translationService = inject(TranslationService);
   private readonly fb = inject(FormBuilder);
 
-  protected readonly chart = viewChild(BaseChartDirective);
+  protected readonly chart = viewChild<BaseChartDirective>('chart');
   protected readonly resultsAnchor = viewChild<ElementRef<HTMLElement>>('resultsAnchor');
   protected readonly resultsHeadingEl = viewChild<ElementRef<HTMLElement>>('resultsHeading');
 
@@ -367,8 +367,10 @@ export class PredictionToolComponent implements OnInit {
             color: (context: any) =>
               context.index === 0 ? colors.gridColor : colors.dashedGridColor,
             lineWidth: 1,
-            borderDash: ((context: any) => (context.index === 0 ? [] : [3, 4])) as any,
-            drawBorder: false
+            borderDash: ((context: any) => (context.index === 0 ? [] : [3, 4])) as any
+          },
+          border: {
+            display: false
           },
           ticks: {
             color: colors.mutedForeground,
@@ -473,7 +475,7 @@ export class PredictionToolComponent implements OnInit {
         console.error('Prediction request failed', { error, request: request.payload });
         this.errorMessage.set(this.t('error_fetch'));
       }
-    });
+    }, { allowSignalWrites: true });
   }
 
   protected onDocumentKeyDown(event: KeyboardEvent): void {

--- a/src/app/prediction-tool/prediction-tool.component.ts
+++ b/src/app/prediction-tool/prediction-tool.component.ts
@@ -74,16 +74,11 @@ type PredictionFormValue = {
 
 type StoredPredictionFormValue = {
   mlModel?: MlModel;
-  ml_model?: MlModel;
   town?: Town;
   storeyRange?: StoreyRange;
-  storey_range?: StoreyRange;
   flatModel?: FlatModel;
-  flat_model?: FlatModel;
   floorAreaSqm?: number | null;
-  floor_area_sqm?: number | null;
   leaseCommenceYear?: number | string | null;
-  lease_commence_year?: number | null;
 };
 
 type PredictionRequestTrigger = {
@@ -154,11 +149,11 @@ export class PredictionToolComponent implements OnInit {
 
   protected readonly predictionResource = resource({
     params: () => this.predictionRequest(),
-    loader: async ({ params: request }) => {
+    loader: async ({ params: request, abortSignal }) => {
       if (!request) {
         return undefined;
       }
-      return this.predictionService.fetchPrediction(request.payload);
+      return this.predictionService.fetchPrediction(request.payload, abortSignal);
     }
   });
 
@@ -456,7 +451,11 @@ export class PredictionToolComponent implements OnInit {
         return;
       }
 
-      if (status === 'resolved' && this.predictionResource.hasValue()) {
+      if (
+        status === 'resolved' &&
+        this.predictionResource.hasValue() &&
+        request.seq === this.predictionRequest()?.seq
+      ) {
         this.hasPrediction.set(true);
         this.errorMessage.set('');
         this.chart()?.update();
@@ -719,27 +718,18 @@ export class PredictionToolComponent implements OnInit {
     }
 
     this.predictionForm.patchValue({
-      ml_model: coerceOption(
-        savedForm.ml_model ?? savedForm.mlModel,
-        ml_model_list
-      ),
+      ml_model: coerceOption(savedForm.mlModel, ml_model_list),
       town: coerceOption(savedForm.town, town_list),
-      storey_range: coerceOption(
-        savedForm.storey_range ?? savedForm.storeyRange,
-        storey_range_list
-      ),
-      flat_model: coerceOption(
-        savedForm.flat_model ?? savedForm.flatModel,
-        flat_model_list
-      ),
+      storey_range: coerceOption(savedForm.storeyRange, storey_range_list),
+      flat_model: coerceOption(savedForm.flatModel, flat_model_list),
       floor_area_sqm: clampNumber(
-        savedForm.floor_area_sqm ?? savedForm.floorAreaSqm,
+        savedForm.floorAreaSqm,
         MIN_FLOOR_AREA,
         MAX_FLOOR_AREA,
         MIN_FLOOR_AREA
       ),
       lease_commence_year: clampNumber(
-        savedForm.lease_commence_year ?? savedForm.leaseCommenceYear,
+        savedForm.leaseCommenceYear,
         MIN_YEAR,
         MAX_YEAR,
         MAX_YEAR

--- a/src/app/services/prediction.service.ts
+++ b/src/app/services/prediction.service.ts
@@ -1,0 +1,232 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Temporal } from '@js-temporal/polyfill';
+import { firstValueFrom } from 'rxjs';
+
+import {
+  flat_model_list,
+  ml_model_list,
+  month_list,
+  storey_range_list,
+  town_list
+} from '../lists';
+
+export type MlModel = (typeof ml_model_list)[number];
+export type Town = (typeof town_list)[number];
+export type StoreyRange = (typeof storey_range_list)[number];
+export type FlatModel = (typeof flat_model_list)[number];
+
+export type TrendPoint = {
+  label: string;
+  value: number;
+};
+
+export type ApiResponse = {
+  predictions: Array<{
+    month: string;
+    predictedPrice: number;
+  }>;
+};
+
+export type PredictionRequestPayload = {
+  model: MlModel;
+  monthStart: string;
+  monthEnd: string;
+  town: Town;
+  storeyRange: StoreyRange;
+  flatModel: FlatModel;
+  floorAreaSqm: string;
+  leaseCommenceYear: string;
+};
+
+export const PREDICTION_API_URL =
+  'https://ee4802-g20-tool-ng.shenghaoc.workers.dev/api/prices';
+
+export const MIN_YEAR = 1960;
+export const MAX_YEAR = Temporal.PlainYearMonth.from(
+  month_list[month_list.length - 1]
+).year;
+export const MIN_FLOOR_AREA = 20;
+export const MAX_FLOOR_AREA = 300;
+export const PREDICTION_MONTHS = [...month_list.slice(-13)];
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PredictionService {
+  private readonly http = inject(HttpClient);
+
+  async fetchPrediction(payload: PredictionRequestPayload): Promise<ApiResponse> {
+    const formData = createPredictionFormData(payload);
+    const responseText = await firstValueFrom(
+      this.http.post(PREDICTION_API_URL, formData, { responseType: 'text' })
+    );
+    return parsePredictionResponse(responseText, payload);
+  }
+}
+
+export function normalizeTrendData(data: ApiResponse): TrendPoint[] {
+  return data.predictions.map((entry) => ({
+    label: entry.month,
+    value: sanitizeCurrencyValue(entry.predictedPrice)
+  }));
+}
+
+export function getPredictionWindow(): {
+  monthStart: string;
+  monthEnd: string;
+} {
+  return {
+    monthStart: PREDICTION_MONTHS[0] ?? month_list[0],
+    monthEnd:
+      PREDICTION_MONTHS[PREDICTION_MONTHS.length - 1] ??
+      month_list[month_list.length - 1]
+  };
+}
+
+export function createDefaultTrendData(): TrendPoint[] {
+  return PREDICTION_MONTHS.map((month) => ({
+    label: month,
+    value: 0
+  }));
+}
+
+export function buildPredictionRequestPayload(formValue: {
+  ml_model: MlModel;
+  town: Town;
+  storey_range: StoreyRange;
+  flat_model: FlatModel;
+  floor_area_sqm: number;
+  lease_commence_year: number;
+}): PredictionRequestPayload {
+  const predictionWindow = getPredictionWindow();
+  return {
+    model: formValue.ml_model,
+    monthStart: predictionWindow.monthStart,
+    monthEnd: predictionWindow.monthEnd,
+    town: formValue.town,
+    storeyRange: formValue.storey_range,
+    flatModel: formValue.flat_model,
+    floorAreaSqm: formValue.floor_area_sqm.toString(),
+    leaseCommenceYear: formValue.lease_commence_year.toString()
+  };
+}
+
+function createPredictionFormData(
+  payload: PredictionRequestPayload
+): FormData {
+  const formData = new FormData();
+
+  Object.entries(payload).forEach(([key, value]) => {
+    formData.append(key, value);
+  });
+
+  return formData;
+}
+
+function parsePredictionResponse(
+  responseText: string,
+  requestPayload: PredictionRequestPayload
+): ApiResponse {
+  let parsedResponse: unknown;
+
+  try {
+    parsedResponse = JSON.parse(responseText) as unknown;
+  } catch {
+    throw new Error(
+      formatPredictionError(
+        'API returned invalid JSON',
+        responseText,
+        requestPayload
+      )
+    );
+  }
+
+  if (
+    !parsedResponse ||
+    typeof parsedResponse !== 'object' ||
+    !('predictions' in parsedResponse) ||
+    !Array.isArray(parsedResponse.predictions) ||
+    parsedResponse.predictions.length === 0
+  ) {
+    throw new Error(
+      formatPredictionError(
+        'API returned an unexpected payload',
+        responseText,
+        requestPayload
+      )
+    );
+  }
+
+  return parsedResponse as ApiResponse;
+}
+
+function formatPredictionError(
+  summary: string,
+  responseText: string,
+  requestPayload: PredictionRequestPayload
+): string {
+  const responsePreview = formatDebugValue(responseText);
+  const requestPreview = JSON.stringify(requestPayload);
+  return `${summary}. Response: ${responsePreview}. Request: ${requestPreview}`;
+}
+
+function formatDebugValue(value: string, maxLength = 280): string {
+  const compactValue = value.replace(/\s+/g, ' ').trim();
+
+  if (!compactValue) {
+    return '(empty response body)';
+  }
+
+  if (compactValue.length <= maxLength) {
+    return compactValue;
+  }
+
+  return `${compactValue.slice(0, maxLength)}...`;
+}
+
+export function sanitizeCurrencyValue(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.round(value));
+}
+
+export function roundValue(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.round(value);
+}
+
+export function coerceOption<T extends readonly string[]>(
+  value: unknown,
+  options: T
+): T[number] {
+  if (typeof value === 'string' && options.includes(value as T[number])) {
+    return value as T[number];
+  }
+
+  return options[0];
+}
+
+export function clampNumber(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number
+): number {
+  const n =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number(value)
+        : NaN;
+  if (!Number.isFinite(n)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, Math.round(n)));
+}

--- a/src/app/services/prediction.service.ts
+++ b/src/app/services/prediction.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Temporal } from '@js-temporal/polyfill';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, fromEvent, takeUntil } from 'rxjs';
 
 import {
   flat_model_list,
@@ -56,11 +56,24 @@ export const PREDICTION_MONTHS = [...month_list.slice(-13)];
 export class PredictionService {
   private readonly http = inject(HttpClient);
 
-  async fetchPrediction(payload: PredictionRequestPayload): Promise<ApiResponse> {
+  async fetchPrediction(
+    payload: PredictionRequestPayload,
+    abortSignal?: AbortSignal
+  ): Promise<ApiResponse> {
+    if (abortSignal?.aborted) {
+      throw new DOMException('Prediction request aborted', 'AbortError');
+    }
+
     const formData = createPredictionFormData(payload);
-    const responseText = await firstValueFrom(
-      this.http.post(PREDICTION_API_URL, formData, { responseType: 'text' })
-    );
+    let request$ = this.http.post(PREDICTION_API_URL, formData, {
+      responseType: 'text'
+    });
+
+    if (abortSignal) {
+      request$ = request$.pipe(takeUntil(fromEvent(abortSignal, 'abort')));
+    }
+
+    const responseText = await firstValueFrom(request$);
     return parsePredictionResponse(responseText, payload);
   }
 }
@@ -142,12 +155,18 @@ function parsePredictionResponse(
     );
   }
 
+  const predictions =
+    parsedResponse &&
+    typeof parsedResponse === 'object' &&
+    'predictions' in parsedResponse &&
+    Array.isArray(parsedResponse.predictions)
+      ? parsedResponse.predictions
+      : null;
+
   if (
-    !parsedResponse ||
-    typeof parsedResponse !== 'object' ||
-    !('predictions' in parsedResponse) ||
-    !Array.isArray(parsedResponse.predictions) ||
-    parsedResponse.predictions.length === 0
+    !predictions ||
+    predictions.length === 0 ||
+    !predictions.every(isValidPredictionEntry)
   ) {
     throw new Error(
       formatPredictionError(
@@ -158,7 +177,20 @@ function parsePredictionResponse(
     );
   }
 
-  return parsedResponse as ApiResponse;
+  return { predictions };
+}
+
+function isValidPredictionEntry(
+  entry: unknown
+): entry is ApiResponse['predictions'][number] {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    'month' in entry &&
+    typeof entry.month === 'string' &&
+    'predictedPrice' in entry &&
+    typeof entry.predictedPrice === 'number'
+  );
 }
 
 function formatPredictionError(

--- a/src/app/services/prediction.service.ts
+++ b/src/app/services/prediction.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Temporal } from '@js-temporal/polyfill';
-import { firstValueFrom, fromEvent, takeUntil } from 'rxjs';
+import { EmptyError, firstValueFrom, fromEvent, takeUntil } from 'rxjs';
 
 import {
   flat_model_list,
@@ -73,8 +73,15 @@ export class PredictionService {
       request$ = request$.pipe(takeUntil(fromEvent(abortSignal, 'abort')));
     }
 
-    const responseText = await firstValueFrom(request$);
-    return parsePredictionResponse(responseText, payload);
+    try {
+      const responseText = await firstValueFrom(request$);
+      return parsePredictionResponse(responseText, payload);
+    } catch (error) {
+      if (error instanceof EmptyError || abortSignal?.aborted) {
+        throw new DOMException('Prediction request aborted', 'AbortError');
+      }
+      throw error;
+    }
   }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>

--- a/src/material-theme.scss
+++ b/src/material-theme.scss
@@ -1,0 +1,32 @@
+
+// Include theming for Angular Material with `mat.theme()`.
+// This Sass mixin will define CSS variables that are used for styling Angular Material
+// components according to the Material 3 design spec.
+// Learn more about theming and how to use it for your application's
+// custom components at https://material.angular.dev/guide/theming
+@use '@angular/material' as mat;
+
+html {
+  height: 100%;
+  @include mat.theme((
+    color: (
+      primary: mat.$azure-palette,
+      tertiary: mat.$blue-palette,
+    ),
+    typography: Roboto,
+    density: 0,
+  ));
+}
+
+body {
+  color-scheme: light dark;
+  background-color: var(--background);
+  color: var(--foreground);
+  font: var(--mat-sys-body-medium);
+  margin: 0;
+  height: 100%;
+}
+
+body[data-theme='dark'] {
+  color-scheme: dark;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -258,3 +258,34 @@ input[type='number'] {
     animation: none !important;
   }
 }
+
+/* ── Chart Frame ──────────────────────────────────────────────────
+   Global so the deferred PredictionChartComponent's frame and the
+   loading placeholder (rendered by the parent) share one definition. */
+.chart-frame {
+  min-height: 340px;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: 8px;
+  border-radius: var(--radius-sm, 3px);
+  border: 1px solid var(--border);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--secondary) 20%, transparent) 0%,
+    color-mix(in oklab, var(--secondary) 5%, transparent) 100%
+  );
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
+}
+
+.chart-frame-placeholder {
+  align-items: center;
+  justify-content: center;
+}
+
+.chart-frame canvas {
+  width: 100% !important;
+  height: 100% !important;
+}

--- a/src/tests/smoke.browser.spec.ts
+++ b/src/tests/smoke.browser.spec.ts
@@ -5,8 +5,6 @@ import { AppComponent } from '../app/app.component';
 import { appConfig } from '../app/app.config';
 
 describe('Prediction Tool - Browser Smoke Test', () => {
-  // Mount the Angular application once before all tests.
-  // Guard against watch-mode reruns where beforeAll may fire again.
   beforeAll(async () => {
     if (!document.querySelector('app-root')) {
       const appRoot = document.createElement('app-root');
@@ -15,13 +13,10 @@ describe('Prediction Tool - Browser Smoke Test', () => {
     }
   });
 
-  // Wait for the app to render before each test
   beforeEach(async () => {
     await expect.element(page.getByRole('main')).toBeVisible();
   });
 
-  // Reset form state between tests so earlier tests' selections
-  // don't leak into later tests (e.g. combobox select affecting spinbutton).
   afterEach(async () => {
     const resetBtn = page.getByRole('button', { name: /reset/i });
     if ((await resetBtn.all()).length > 0) {
@@ -34,45 +29,28 @@ describe('Prediction Tool - Browser Smoke Test', () => {
     await expect.element(headings.first()).toBeVisible();
   });
 
-  it('should open the ML Model combobox and select an option', async () => {
-    // First combobox on the page (ML Model)
-    const mlModelInput = page.getByRole('combobox').first();
-    await expect.element(mlModelInput).toBeVisible();
+  it('should open the ML Model select and choose an option', async () => {
+    const mlModelSelect = page.getByRole('combobox', { name: /ml model/i });
+    await expect.element(mlModelSelect).toBeVisible();
+    await mlModelSelect.click();
 
-    // Click the first toggle button (ML Model combobox's chevron)
-    const toggleButton = page.getByRole('button', { name: /toggle/i }).first();
-    await toggleButton.click();
+    const ridgeOption = page.getByRole('option', { name: /ridge regression/i });
+    await ridgeOption.click();
 
-    // Wait for the listbox to appear and select first option
-    const listbox = page.getByRole('listbox');
-    await expect.element(listbox).toBeVisible();
-    const firstOption = listbox.getByRole('option').first();
-    await firstOption.click();
-
-    // Verify the combobox value was updated
-    const el = mlModelInput.element() as HTMLInputElement;
-    expect(el.value).toBeTruthy();
+    await expect.element(mlModelSelect).toHaveTextContent(/ridge regression/i);
   });
 
-  it('should type in the number field and verify stepper works', async () => {
-    // The number field uses role="spinbutton"
-    const numberInput = page.getByRole('spinbutton');
-    await expect.element(numberInput).toBeVisible();
+  it('should type in the floor area field', async () => {
+    const floorAreaInput = page.getByRole('spinbutton', { name: /floor area/i });
+    await expect.element(floorAreaInput).toBeVisible();
+    await floorAreaInput.fill('120');
 
-    // Clear and type a value
-    await numberInput.fill('120');
-
-    // Click the increase stepper button
-    const increaseButton = page.getByRole('button', { name: /increase/i });
-    await increaseButton.click();
-
-    // Value should have increased
-    const input = numberInput.element() as HTMLInputElement;
-    expect(Number(input.value)).toBeGreaterThan(120);
+    const input = floorAreaInput.element() as HTMLInputElement;
+    expect(Number(input.value)).toBe(120);
   });
 
-  it('should have aria-required on the number field', async () => {
-    const numberInput = page.getByRole('spinbutton');
-    await expect.element(numberInput).toHaveAttribute('aria-required', 'true');
+  it('should mark the floor area field as required', async () => {
+    const floorAreaInput = page.getByRole('spinbutton', { name: /floor area/i });
+    await expect.element(floorAreaInput).toHaveAttribute('required');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the prediction tool’s **form → fetch → display** flow to idiomatic Angular 21 patterns while preserving all existing behavior and the prediction API contract.

## Changes

- **Typed reactive forms** with `FormGroup` / `Validators` (`required`, `min`, `max`, integer check for floor area) using snake_case control names aligned with the shared contract (`ml_model`, `town`, `storey_range`, `flat_model`, `floor_area_sqm`, `lease_commence_year`).
- **Angular Material** (`mat-form-field`, `mat-select`, `mat-input`) for constrained inputs.
- **`PredictionService`** seam: HTTP POST, FormData payload, and response parsing unchanged (same endpoint and field mapping).
- **`resource()`** for async prediction fetch with `loading` / `error` / result exposed as signals.
- **Template**: `@if` / `@for` control flow; **`@defer (when hasResult())`** around the ng2-charts block.
- **Headline price**: locale-aware SGD via Angular `currency` pipe (`en-SG` / `zh-SG`).
- **Preserved**: zoneless CD, bilingual UI, theme toggle, form persistence (backward-compatible storage keys), chart theme colors, empty state, keyboard shortcuts.

## Verification

- `npm install`
- `npm run build` (passes; initial bundle budget warning due to Material)
- `npm test` (9/9 Vitest browser tests)

## Notes

Custom combobox/number-field components remain in the repo for structure but are no longer used by the main form.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d2a2a0c-8b9a-4564-9eaa-fc959a2a2c75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d2a2a0c-8b9a-4564-9eaa-fc959a2a2c75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

