### PR TITLE
chore: reorg dependabot groups around peer-dependency coupling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
         # the peer conflict and a lone TypeScript PR is unmergeable on its own.
         patterns:
           - '@angular/*'
+          - '@angular-devkit/*'
           - 'typescript'
           - 'tslib'
       types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,22 @@ updates:
       interval: "monthly"
     groups:
       angular:
+        # Angular pins a narrow TypeScript peer range (e.g. @angular/compiler-cli@22
+        # requires typescript >=6.0 <6.1), so TypeScript and tslib must be bumped in
+        # the same PR as @angular/* — otherwise an Angular-major PR fails `npm ci` on
+        # the peer conflict and a lone TypeScript PR is unmergeable on its own.
         patterns:
           - '@angular/*'
-      typescript:
-        patterns:
           - 'typescript'
           - 'tslib'
+      types:
+        patterns:
           - '@types/*'
       testing:
         patterns:
-          - 'jasmine-core'
-          - 'karma'
-          - 'karma-*'
+          - 'vitest'
+          - '@vitest/*'
+          - '@playwright/*'
       charting:
         patterns:
           - 'chart.js'


### PR DESCRIPTION
## Overview

Reorganizes the npm dependabot groups so version bumps respect Angular's peer-dependency coupling, and cleans up dead group config left over from the Karma→Vitest migration.

## Why

Angular pins a **narrow** TypeScript peer range, so Angular and TypeScript are not independently bumpable:

| Package | `typescript` peer range |
| --- | --- |
| `@angular/compiler-cli@22.0.0` | `>=6.0 <6.1` |
| `@angular/compiler-cli@21.2.15` | `>=5.9 <6.1` |

With `angular` and `typescript` in separate groups, dependabot opened two PRs that can't merge in isolation:

- **#123** (Angular 21→22) leaves `typescript ~5.9.3`, which violates Angular 22's `>=6.0` peer → `npm ci` fails.
- **#118** (TypeScript 5.9→6.0) is compatible with Angular 21 but pointless on its own.

## Changes

- **Fold `typescript` + `tslib` into the `angular` group** so an Angular major carries its required TypeScript bump in one atomic PR.
- **Split `@types/*` into a new `types` group** — `@types/node` has no Angular peer coupling, so it shouldn't be gated behind Angular majors.
- **Repoint the dead `testing` group** at the real tooling (`vitest`, `@vitest/*`, `@playwright/*`). It previously matched `jasmine-core` / `karma*`, which were removed in the Vitest+Playwright migration (710c21c) and no longer exist in `package.json`.

## Follow-up for the existing PRs

This config takes effect on dependabot's next run once merged. To collapse the two stuck PRs into one coupled PR now, comment `@dependabot recreate` on **#123** after this lands — it regroups under the new config, pulls TypeScript 6.0 in, and closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)